### PR TITLE
「Lambda: 関数を呼び出し」アクションに対応した

### DIFF
--- a/examples/resources/job/action/invoke_lambda_function/main.tf
+++ b/examples/resources/job/action/invoke_lambda_function/main.tf
@@ -1,0 +1,26 @@
+# ----------------------------------------------------------
+# - アクション
+#   - Lambda: 関数を呼び出し
+# - アクションの設定
+#   - AWSリージョン
+#     - ap-northeast-1
+#   - Lambda関数名
+#     - test-function
+#   - イベントJSON
+#     - {}
+# ----------------------------------------------------------
+
+resource "cloudautomator_job" "example-invoke-lambda-function-job" {
+  name           = "example-invoke-lambda-function-job"
+  group_id       = 10
+  aws_account_id = 20
+
+  rule_type = "webhook"
+
+  action_type = "invoke_lambda_function"
+  invoke_lambda_function_action_value {
+    region        = "ap-northeast-1"
+    function_name = "test-function"
+    payload       = "{}"
+  }
+}

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -91,6 +91,7 @@ var TRACE_STATUS_NOT_SUPPORTED_ACTION_TYPES = []string{
 	"deregister_target_instances",
 	"describe_metadata",
 	"google_compute_insert_machine_image",
+	"invoke_lambda_function",
 	"reboot_rds_instances",
 	"register_instances",
 	"register_target_instances",

--- a/internal/provider/resource_job.go
+++ b/internal/provider/resource_job.go
@@ -301,6 +301,15 @@ func resourceJob() *schema.Resource {
 					Schema: gcp.GoogleComputeInsertMachineImageActionValueFields(),
 				},
 			},
+			"invoke_lambda_function_action_value": {
+				Description: "\"Lambda: Invoke lambda function\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: aws.InvokeLambdaFunctionActionValueFields(),
+				},
+			},
 			"reboot_rds_instances_action_value": {
 				Description: "\"RDS: Reboot DB instance\" action value",
 				Type:        schema.TypeList,

--- a/internal/provider/resource_job_test.go
+++ b/internal/provider/resource_job_test.go
@@ -1118,6 +1118,40 @@ func TestAccCloudAutomatorJob_GoogleComputeInsertMachineImageAction(t *testing.T
 	})
 }
 
+func TestAccCloudAutomatorJob_InvokeLambdaFunctionAction(t *testing.T) {
+	resourceName := "cloudautomator_job.test"
+	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
+	postProcessId := acctest.TestPostProcessId()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckCloudAutomatorJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudAutomatorJobConfigInvokeLambdaFunctionAction(jobName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudAutomatorJobExists(testAccProviders["cloudautomator"], resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", jobName),
+					resource.TestCheckResourceAttr(
+						resourceName, "action_type", "invoke_lambda_function"),
+					resource.TestCheckResourceAttr(
+						resourceName, "invoke_lambda_function_action_value.0.region", "ap-northeast-1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "invoke_lambda_function_action_value.0.function_name", "test-function"),
+					resource.TestCheckResourceAttr(
+						resourceName, "invoke_lambda_function_action_value.0.payload", "{}"),
+					resource.TestCheckResourceAttr(
+						resourceName, "completed_post_process_id.0", postProcessId),
+					resource.TestCheckResourceAttr(
+						resourceName, "failed_post_process_id.0", postProcessId),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudAutomatorJob_RebootRdsInstancesAction(t *testing.T) {
 	resourceName := "cloudautomator_job.test"
 	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
@@ -2748,6 +2782,26 @@ resource "cloudautomator_job" "test" {
 		specify_rds_instance = "tag"
 		tag_key = "env"
 		tag_value = "develop"
+	}
+	completed_post_process_id = [%s]
+	failed_post_process_id = [%s]
+}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}
+
+func testAccCheckCloudAutomatorJobConfigInvokeLambdaFunctionAction(rName string) string {
+	return fmt.Sprintf(`
+resource "cloudautomator_job" "test" {
+	name = "%s"
+	group_id = "%s"
+	aws_account_id = "%s"
+
+	rule_type = "webhook"
+
+	action_type = "invoke_lambda_function"
+	invoke_lambda_function_action_value {
+		region = "ap-northeast-1"
+		function_name = "test-function"
+		payload = "{}"
 	}
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]

--- a/internal/schemes/job/aws/lambda.go
+++ b/internal/schemes/job/aws/lambda.go
@@ -1,0 +1,25 @@
+package schemes
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func InvokeLambdaFunctionActionValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"region": {
+			Description: "AWS Region in which the target resource resides",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"function_name": {
+			Description: "Function name",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"payload": {
+			Description: "Event JSON",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+	}
+}

--- a/internal/schemes/job/gcp/compute_engin.go
+++ b/internal/schemes/job/gcp/compute_engin.go
@@ -42,8 +42,8 @@ func GoogleComputeInsertMachineImageActionValueFields() map[string]*schema.Schem
 			Required:    true,
 		},
 		"generation": {
-			Description: "Tag value used to identify the target resource",
-			Type:        schema.TypeString,
+			Description: "Number of machine image generations",
+			Type:        schema.TypeInt,
 			Required:    true,
 		},
 		"project_id": {


### PR DESCRIPTION
「Lambda: 関数を呼び出し」アクションに対応しました。

**resource example**

```tf
resource "cloudautomator_job" "example-invoke-lambda-function-job" {
  name           = "example-invoke-lambda-function-job"
  group_id       = 10
  aws_account_id = 20

  rule_type = "webhook"

  action_type = "invoke_lambda_function"
  invoke_lambda_function_action_value {
    region        = "ap-northeast-1"
    function_name = "test-function"
    payload       = "{}"
  }
}
```