### PR TITLE
「Compute Engine: VMインスタンスを停止」アクションに対応した

### DIFF
--- a/examples/resources/job/action/google_compute_stop_vm_instances/main.tf
+++ b/examples/resources/job/action/google_compute_stop_vm_instances/main.tf
@@ -1,0 +1,31 @@
+# ----------------------------------------------------------
+# - アクション
+#   - Compute Engine: VMインスタンスを停止
+# - アクションの設定
+#   - リージョン
+#     - asia-northeast1
+#   - プロジェクトID
+#     - example-project
+#   - VMインスタンスをラベルで指定
+#     - ラベルのキー
+#       - env
+#     - ラベルの値
+#       - develop
+# ----------------------------------------------------------
+
+resource "cloudautomator_job" "example-google-compute-stop-vm-instances-image" {
+  name                    = "example-google-compute-stop-vm-instances-image"
+  group_id                = 10
+  google_cloud_account_id = 20
+
+  rule_type = "webhook"
+
+  action_type = "google_compute_stop_vm_instances"
+  google_compute_stop_vm_instances_action_value {
+    region                  = "asia-northeast1"
+    project_id              = "example-project"
+    specify_vm_instance     = "label"
+    vm_instance_label_key   = "env"
+    vm_instance_label_value = "develop"
+  }
+}

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -91,6 +91,7 @@ var TRACE_STATUS_NOT_SUPPORTED_ACTION_TYPES = []string{
 	"deregister_target_instances",
 	"describe_metadata",
 	"google_compute_insert_machine_image",
+	"google_compute_stop_vm_instances",
 	"invoke_lambda_function",
 	"reboot_rds_instances",
 	"register_instances",

--- a/internal/provider/resource_job.go
+++ b/internal/provider/resource_job.go
@@ -301,6 +301,15 @@ func resourceJob() *schema.Resource {
 					Schema: gcp.GoogleComputeInsertMachineImageActionValueFields(),
 				},
 			},
+			"google_compute_stop_vm_instances_action_value": {
+				Description: "\"Compute Engine: stop vm instances\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: gcp.GoogleComputeStopVmInstancesActionValueFields(),
+				},
+			},
 			"invoke_lambda_function_action_value": {
 				Description: "\"Lambda: Invoke lambda function\" action value",
 				Type:        schema.TypeList,

--- a/internal/provider/resource_job_test.go
+++ b/internal/provider/resource_job_test.go
@@ -1118,6 +1118,44 @@ func TestAccCloudAutomatorJob_GoogleComputeInsertMachineImageAction(t *testing.T
 	})
 }
 
+func TestAccCloudAutomatorJob_GoogleComputeStopVmInstancesAction(t *testing.T) {
+	resourceName := "cloudautomator_job.test"
+	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
+	postProcessId := acctest.TestPostProcessId()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckCloudAutomatorJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudAutomatorJobConfigGoogleComputeStopVmInstancesAction(jobName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudAutomatorJobExists(testAccProviders["cloudautomator"], resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", jobName),
+					resource.TestCheckResourceAttr(
+						resourceName, "action_type", "google_compute_stop_vm_instances"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_stop_vm_instances_action_value.0.region", "asia-northeast1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_stop_vm_instances_action_value.0.project_id", "example-project"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_stop_vm_instances_action_value.0.specify_vm_instance", "label"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_stop_vm_instances_action_value.0.vm_instance_label_key", "env"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_stop_vm_instances_action_value.0.vm_instance_label_value", "develop"),
+					resource.TestCheckResourceAttr(
+						resourceName, "completed_post_process_id.0", postProcessId),
+					resource.TestCheckResourceAttr(
+						resourceName, "failed_post_process_id.0", postProcessId),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudAutomatorJob_InvokeLambdaFunctionAction(t *testing.T) {
 	resourceName := "cloudautomator_job.test"
 	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
@@ -2761,6 +2799,26 @@ resource "cloudautomator_job" "test" {
 		machine_image_storage_location = "asia-northeast1"
 		machine_image_basename = "example-daily"
 		generation = 10
+	}
+	completed_post_process_id = [%s]
+	failed_post_process_id = [%s]
+}`, rName, acctest.TestGroupId(), acctest.TestGoogleCloudAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}
+
+func testAccCheckCloudAutomatorJobConfigGoogleComputeStopVmInstancesAction(rName string) string {
+	return fmt.Sprintf(`
+resource "cloudautomator_job" "test" {
+	name = "%s"
+	group_id = "%s"
+	google_cloud_account_id = "%s"
+	rule_type = "webhook"
+	action_type = "google_compute_stop_vm_instances"
+	google_compute_stop_vm_instances_action_value {
+		region = "asia-northeast1"
+		project_id = "example-project"
+		specify_vm_instance = "label"
+        vm_instance_label_key = "env"
+		vm_instance_label_value = "develop"
 	}
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]

--- a/internal/schemes/job/gcp/google_compute_stop_vm_instances.go
+++ b/internal/schemes/job/gcp/google_compute_stop_vm_instances.go
@@ -1,0 +1,40 @@
+package schemes
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func GoogleComputeStopVmInstancesActionValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"region": {
+			Description: "GCP Region in which the target resource resides",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"specify_vm_instance": {
+			Description: "How to specify VM instance",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"vm_instance_label_key": {
+			Description: "label key used to identify the target resource",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"vm_instance_label_value": {
+			Description: "label value used to identify the target resource",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"vm_instance_id": {
+			Description: "VM Instance ID",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"project_id": {
+			Description: "Project ID to which the target VM instance belongs",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+	}
+}


### PR DESCRIPTION
「Compute Engine: VMインスタンスを停止」アクションに対応しました。

**resource example**

```tf
resource "cloudautomator_job" "example-google-compute-stop-vm-instances-image" {
  name                    = "example-google-compute-stop-vm-instances-image"
  group_id                = 10
  google_cloud_account_id = 20

  rule_type = "webhook"

  action_type = "google_compute_stop_vm_instances"
  google_compute_stop_vm_instances_action_value {
    region                         = "asia-northeast1"
    project_id                     = "example-project"
    specify_vm_instance            = "label"
    vm_instance_label_key          = "env"
    vm_instance_label_value        = "develop"
  }
}
```