### PR TITLE
「ECS: タスクを停止」アクションに対応した

### DIFF
--- a/examples/resources/job/action/stop_ecs_tasks/main.tf
+++ b/examples/resources/job/action/stop_ecs_tasks/main.tf
@@ -1,0 +1,32 @@
+# ----------------------------------------------------------
+# - アクション
+#   - ECS: タスクを停止
+# - アクションの設定
+#   - リージョン
+#     - ap-northeast-1
+#   - 対象のECSクラスターの名前
+#    - example-cluster
+#   - ECSタスクの特定方法
+#     - タグ
+#   - タグのキー
+#     - env
+#   - タグの値
+#     - develop
+# ----------------------------------------------------------
+
+resource "cloudautomator_job" "example-stop-ecs-tasks" {
+  name           = "example-stop-ecs-tasks"
+  group_id       = 10
+  aws_account_id = 20
+
+  rule_type = "webhook"
+
+  action_type = "stop_ecs_tasks"
+  stop_ecs_tasks_action_value {
+    region           = "ap-northeast-1"
+    ecs_cluster      = "example-cluster"
+    specify_ecs_task = "tag"
+    tag_key          = "env"
+    tag_value        = "develop"
+  }
+}

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -86,6 +86,7 @@ var TRACE_STATUS_NOT_SUPPORTED_ACTION_TYPES = []string{
 	"authorize_security_group_ingress",
 	"copy_rds_cluster_snapshot",
 	"create_fsx_backup",
+	"stop_ecs_tasks",
 	"change_instance_type",
 	"deregister_instances",
 	"deregister_target_instances",

--- a/internal/provider/data_source_job.go
+++ b/internal/provider/data_source_job.go
@@ -396,6 +396,15 @@ func dataSourceJob() *schema.Resource {
 					Schema: aws.StartRdsInstancesActionValueFields(),
 				},
 			},
+			"stop_ecs_tasks_action_value": {
+				Description: "\"ECS: Stop task\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: aws.StopEcsTasksActionValueFields(),
+				},
+			},
 			"stop_instances_action_value": {
 				Description: "\"EC2: Stop instance\" action value",
 				Type:        schema.TypeList,

--- a/internal/provider/resource_job.go
+++ b/internal/provider/resource_job.go
@@ -445,6 +445,15 @@ func resourceJob() *schema.Resource {
 					Schema: aws.StartRdsInstancesActionValueFields(),
 				},
 			},
+			"stop_ecs_tasks_action_value": {
+				Description: "\"ECS: Stop task\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: aws.StopEcsTasksActionValueFields(),
+				},
+			},
 			"stop_instances_action_value": {
 				Description: "\"EC2: Stop instance\" action value",
 				Type:        schema.TypeList,

--- a/internal/provider/resource_job_test.go
+++ b/internal/provider/resource_job_test.go
@@ -1806,6 +1806,44 @@ func TestAccCloudAutomatorJob_StartRdsInstancesAction(t *testing.T) {
 	})
 }
 
+func TestAccCloudAutomatorJob_StopEcsTasksAction(t *testing.T) {
+	resourceName := "cloudautomator_job.test"
+	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
+	postProcessId := acctest.TestPostProcessId()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckCloudAutomatorJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudAutomatorJobConfigStopEcsTasksAction(jobName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudAutomatorJobExists(testAccProviders["cloudautomator"], resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", jobName),
+					resource.TestCheckResourceAttr(
+						resourceName, "action_type", "stop_ecs_tasks"),
+					resource.TestCheckResourceAttr(
+						resourceName, "stop_ecs_tasks_action_value.0.region", "ap-northeast-1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "stop_ecs_tasks_action_value.0.ecs_cluster", "example-cluster"),
+					resource.TestCheckResourceAttr(
+						resourceName, "stop_ecs_tasks_action_value.0.specify_ecs_task", "tag"),
+					resource.TestCheckResourceAttr(
+						resourceName, "stop_ecs_tasks_action_value.0.tag_key", "env"),
+					resource.TestCheckResourceAttr(
+						resourceName, "stop_ecs_tasks_action_value.0.tag_value", "develop"),
+					resource.TestCheckResourceAttr(
+						resourceName, "completed_post_process_id.0", postProcessId),
+					resource.TestCheckResourceAttr(
+						resourceName, "failed_post_process_id.0", postProcessId),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudAutomatorJob_StopInstancesAction(t *testing.T) {
 	resourceName := "cloudautomator_job.test"
 	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
@@ -3239,6 +3277,29 @@ resource "cloudautomator_job" "test" {
 		tag_value = "develop"
 		trace_status = "true"
 	}
+	completed_post_process_id = [%s]
+	failed_post_process_id = [%s]
+}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}
+
+func testAccCheckCloudAutomatorJobConfigStopEcsTasksAction(rName string) string {
+	return fmt.Sprintf(`
+resource "cloudautomator_job" "test" {
+	name = "%s"
+	group_id = "%s"
+	aws_account_id = "%s"
+
+	rule_type = "webhook"
+
+	action_type = "stop_ecs_tasks"
+	stop_ecs_tasks_action_value {
+		region = "ap-northeast-1"
+		ecs_cluster = "example-cluster"
+		specify_ecs_task = "tag"
+		tag_key = "env"
+		tag_value = "develop"
+	}
+
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]
 }`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())

--- a/internal/schemes/job/aws/ec2.go
+++ b/internal/schemes/job/aws/ec2.go
@@ -469,6 +469,41 @@ func StartInstancesActionValueFields() map[string]*schema.Schema {
 	}
 }
 
+func StopEcsTasksActionValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"region": {
+			Description: "AWS Region in which the target resource resides",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"ecs_cluster": {
+			Description: "Target ECS cluster name",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"specify_ecs_task": {
+			Description: "How to identify target resources",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"ecs_task_definition_family": {
+			Description: "ECS task definition family name",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"tag_key": {
+			Description: "Tag key used to identify the target resource",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"tag_value": {
+			Description: "Tag value used to identify the target resource",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+	}
+}
+
 func StopInstancesActionValueFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"region": {


### PR DESCRIPTION
「ECS: タスクを停止」アクションに対応しました。

**resource example**

```tf
resource "cloudautomator_job" "example-stop-ecs-tasks" {
  name                    = "example-stop-ecs-tasks"
  group_id                = 10
  aws_account_id = 20

  rule_type = "webhook"

  action_type = "stop_ecs_tasks"
  stop_ecs_tasks_action_value {
    region = "ap-northeast-1"
    ecs_cluster = "example-cluster"
    specify_ecs_task = "tag"
    tag_key = "env"
    tag_value = "develop"
  }
}
```