### PR TITLE
「ECS：タスクを実行（Fargate）」アクションに対応した

### DIFF
--- a/examples/resources/job/action/run_ecs_tasks_fargate/main.tf
+++ b/examples/resources/job/action/run_ecs_tasks_fargate/main.tf
@@ -1,0 +1,52 @@
+# ----------------------------------------------------------
+# - アクション
+#   - ECS: タスクを実行 (Fargate)
+# - アクションの設定
+#   - リージョン
+#     - ap-northeast-1
+#   - 対象のECSクラスターの名前
+#     - example-cluster
+#   - タスクが使用するプラットフォームのバージョン
+#     - LATEST
+#   - タスク定義のファミリー
+#     - example-service
+#   - 起動するタスク数
+#     - 1
+#   - タグをタスク定義からタスクに伝播するかどうか
+#     - 伝播させる
+#   - タスクにAmazon ECS管理タグを付与するかどうか
+#     - 付与する
+#   - 使用するVPC
+#     - vpc-00000001
+#   - 使用するサブネット
+#     - subnet-00000001
+#     - subnet-00000002
+#   - 使用するセキュリティグループ
+#     - sg-00000001
+#     - sg-00000002
+#   - パブリックIP割当を有効にするかどうか
+#     - 有効にする
+# ----------------------------------------------------------
+
+resource "cloudautomator_job" "example-run-ecs-tasks-fargate-job" {
+  name           = "example-run-ecs-tasks-fargate-job"
+  group_id       = 10
+  aws_account_id = 20
+
+  rule_type = "immediate_execution"
+
+  action_type = "run_ecs_tasks_fargate"
+  run_ecs_tasks_fargate_action_value {
+    region                      = "ap-northeast-1"
+    ecs_cluster                 = "example-cluster"
+    platform_version            = "LATEST"
+    ecs_task_definition_family  = "example-service"
+    ecs_task_count              = 1
+    propagate_tags              = "TASK_DEFINITION"
+    enable_ecs_managed_tags     = true
+    ecs_awsvpc_vpc              = "vpc-00000001"
+    ecs_awsvpc_subnets          = ["subnet-00000001", "subnet-00000002"]
+    ecs_awsvpc_security_groups  = ["sg-00000001", "sg-00000002"]
+    ecs_awsvpc_assign_public_ip = "ENABLED"
+  }
+}

--- a/internal/provider/data_source_job.go
+++ b/internal/provider/data_source_job.go
@@ -360,6 +360,15 @@ func dataSourceJob() *schema.Resource {
 					Schema: aws.RevokeSecurityGroupIngressActionValueFields(),
 				},
 			},
+			"run_ecs_tasks_fargate_action_value": {
+				Description: "\"ECS: Run task (Fargate)\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: aws.RunEcsTasksFargateActionValueFields(),
+				},
+			},
 			"send_command_action_value": {
 				Description: "\"EC2: Send command on instance\" action value",
 				Type:        schema.TypeList,

--- a/internal/provider/resource_job.go
+++ b/internal/provider/resource_job.go
@@ -409,6 +409,15 @@ func resourceJob() *schema.Resource {
 					Schema: aws.RevokeSecurityGroupIngressActionValueFields(),
 				},
 			},
+			"run_ecs_tasks_fargate_action_value": {
+				Description: "\"ECS: Run task (Fargate)\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: aws.RunEcsTasksFargateActionValueFields(),
+				},
+			},
 			"send_command_action_value": {
 				Description: "\"EC2: Send command on instance\" action value",
 				Type:        schema.TypeList,

--- a/internal/provider/resource_job_test.go
+++ b/internal/provider/resource_job_test.go
@@ -1638,6 +1638,64 @@ func TestAccCloudAutomatorJob_RevokeSecurityGroupIngressAction(t *testing.T) {
 	})
 }
 
+func TestAccCloudAutomatorJob_RunEcsTasksFargateAction(t *testing.T) {
+	resourceName := "cloudautomator_job.test"
+	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
+	postProcessId := acctest.TestPostProcessId()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckCloudAutomatorJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudAutomatorJobConfigRunEcsTasksFargateAction(jobName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudAutomatorJobExists(testAccProviders["cloudautomator"], resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", jobName),
+					resource.TestCheckResourceAttr(
+						resourceName, "action_type", "run_ecs_tasks_fargate"),
+					resource.TestCheckResourceAttr(
+						resourceName, "run_ecs_tasks_fargate_action_value.0.region", "ap-northeast-1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "run_ecs_tasks_fargate_action_value.0.ecs_cluster", "example-cluster"),
+					resource.TestCheckResourceAttr(
+						resourceName, "run_ecs_tasks_fargate_action_value.0.platform_version", "LATEST"),
+					resource.TestCheckResourceAttr(
+						resourceName, "run_ecs_tasks_fargate_action_value.0.ecs_task_definition_family", "example-service"),
+					resource.TestCheckResourceAttr(
+						resourceName, "run_ecs_tasks_fargate_action_value.0.ecs_task_count", "1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "run_ecs_tasks_fargate_action_value.0.propagate_tags", "TASK_DEFINITION"),
+					resource.TestCheckResourceAttr(
+						resourceName, "run_ecs_tasks_fargate_action_value.0.enable_ecs_managed_tags", "true"),
+					resource.TestCheckResourceAttr(
+						resourceName, "run_ecs_tasks_fargate_action_value.0.ecs_awsvpc_vpc", "vpc-00000001"),
+					resource.TestCheckResourceAttr(
+						resourceName, "run_ecs_tasks_fargate_action_value.0.ecs_awsvpc_subnets.#", "2"),
+					resource.TestCheckResourceAttr(
+						resourceName, "run_ecs_tasks_fargate_action_value.0.ecs_awsvpc_subnets.0", "subnet-00000001"),
+					resource.TestCheckResourceAttr(
+						resourceName, "run_ecs_tasks_fargate_action_value.0.ecs_awsvpc_subnets.1", "subnet-00000002"),
+					resource.TestCheckResourceAttr(
+						resourceName, "run_ecs_tasks_fargate_action_value.0.ecs_awsvpc_security_groups.#", "2"),
+					resource.TestCheckResourceAttr(
+						resourceName, "run_ecs_tasks_fargate_action_value.0.ecs_awsvpc_security_groups.0", "sg-00000001"),
+					resource.TestCheckResourceAttr(
+						resourceName, "run_ecs_tasks_fargate_action_value.0.ecs_awsvpc_security_groups.1", "sg-00000002"),
+					resource.TestCheckResourceAttr(
+						resourceName, "run_ecs_tasks_fargate_action_value.0.ecs_awsvpc_assign_public_ip", "ENABLED"),
+					resource.TestCheckResourceAttr(
+						resourceName, "completed_post_process_id.0", postProcessId),
+					resource.TestCheckResourceAttr(
+						resourceName, "failed_post_process_id.0", postProcessId),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudAutomatorJob_SendCommandAction(t *testing.T) {
 	resourceName := "cloudautomator_job.test"
 	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
@@ -3140,6 +3198,35 @@ resource "cloudautomator_job" "test" {
 		to_port = "80"
 		cidr_ip = "172.31.0.0/16"
 	}
+	completed_post_process_id = [%s]
+	failed_post_process_id = [%s]
+}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}
+
+func testAccCheckCloudAutomatorJobConfigRunEcsTasksFargateAction(rName string) string {
+	return fmt.Sprintf(`
+resource "cloudautomator_job" "test" {
+	name = "%s"
+	group_id = "%s"
+	aws_account_id = "%s"
+
+	rule_type = "webhook"
+
+	action_type = "run_ecs_tasks_fargate"
+	run_ecs_tasks_fargate_action_value {
+		region = "ap-northeast-1"
+		ecs_cluster = "example-cluster"
+		platform_version = "LATEST"
+		ecs_task_definition_family = "example-service"
+		ecs_task_count = 1
+		propagate_tags = "TASK_DEFINITION"
+		enable_ecs_managed_tags = true
+		ecs_awsvpc_vpc = "vpc-00000001"
+		ecs_awsvpc_subnets = ["subnet-00000001", "subnet-00000002"]
+		ecs_awsvpc_security_groups = ["sg-00000001", "sg-00000002"]
+		ecs_awsvpc_assign_public_ip = "ENABLED"
+	}
+
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]
 }`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())

--- a/internal/schemes/job/aws/ecs.go
+++ b/internal/schemes/job/aws/ecs.go
@@ -1,0 +1,67 @@
+package schemes
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func RunEcsTasksFargateActionValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"region": {
+			Description: "AWS Region in which the target resource resides",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"ecs_cluster": {
+			Description: "ECS cluster name",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"platform_version": {
+			Description: "Platform version",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"ecs_task_definition_family": {
+			Description: "ECS task definition family",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"ecs_task_count": {
+			Description: "Number of ECS tasks to run",
+			Type:        schema.TypeInt,
+			Required:    true,
+		},
+		"propagate_tags": {
+			Description: "Propagate tags",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"enable_ecs_managed_tags": {
+			Description: "Enable ECS managed tags",
+			Type:        schema.TypeBool,
+			Required:    true,
+		},
+		"ecs_awsvpc_vpc": {
+			Description: "ECS awsvpc vpc",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"ecs_awsvpc_subnets": {
+			Description: "ECS awsvpc subnets",
+			Type:        schema.TypeList,
+			Required:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+		},
+		"ecs_awsvpc_security_groups": {
+			Description: "ECS awsvpc security groups",
+			Type:        schema.TypeList,
+			Required:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+		},
+		"ecs_awsvpc_assign_public_ip": {
+			Description: "ECS awsvpc assign public ip",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+	}
+}


### PR DESCRIPTION
「ECS：タスクを実行（Fargate）」アクションに対応しました。

**resource example**

```tf
resource "cloudautomator_job" "example-run-ecs-tasks-fargate-job" {
  name           = "example-run-ecs-tasks-fargate-job"
  group_id       = 10
  aws_account_id = 20

  rule_type = "immediate_execution"

  action_type = "run_ecs_tasks_fargate"
  run_ecs_tasks_fargate_action_value {
    region                      = "ap-northeast-1"
    ecs_cluster                 = "example-cluster"
    platform_version            = "LATEST"
    ecs_task_definition_family  = "example-service"
    ecs_task_count              = 1
    propagate_tags              = "TASK_DEFINITION"
    enable_ecs_managed_tags     = true
    ecs_awsvpc_vpc              = "vpc-00000001"
    ecs_awsvpc_subnets          = ["subnet-00000001", "subnet-00000002"]
    ecs_awsvpc_security_groups  = ["sg-00000001", "sg-00000002"]
    ecs_awsvpc_assign_public_ip = "ENABLED"
  }
}
```