### PR TITLE
「EC2: インスタンスをすべて停止」アクションに対応した

### DIFF
--- a/examples/resources/job/action/bulk_stop_instances/main.tf
+++ b/examples/resources/job/action/bulk_stop_instances/main.tf
@@ -1,0 +1,26 @@
+# ----------------------------------------------------------
+# - アクション
+#   - EC2: インスタンスをすべて停止
+# - アクションの設定
+#   - 特定のタグが付いたインスタンスを除外するかどうか
+#     - 除外する
+#   - 除外するインスタンスの特定に利用するタグのキー
+#     - env
+#   - 除外するインスタンスの特定に利用するタグの値
+#     - production
+# ----------------------------------------------------------
+
+resource "cloudautomator_job" "example-bulk-stop-instances-job" {
+  name            = "example-bulk-stop-instances-job"
+  group_id        = 10
+  aws_account_ids = [20]
+
+  rule_type = "immediate_execution"
+
+  action_type = "bulk_stop_instances"
+  bulk_stop_instances_action_value {
+    exclude_by_tag       = true
+    exclude_by_tag_key   = "env"
+    exclude_by_tag_value = "develop"
+  }
+}

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -18,6 +18,7 @@ type Job struct {
 	GroupId                  int                    `json:"group_id"`
 	ForWorkflow              *bool                  `json:"for_workflow,omitempty"`
 	AwsAccountId             int                    `json:"aws_account_id,omitempty"`
+	AwsAccountIds            []int                  `json:"aws_account_ids,omitempty"`
 	GoogleCloudAccountId     int                    `json:"google_cloud_account_id,omitempty"`
 	RuleType                 string                 `json:"rule_type"`
 	RuleValue                map[string]interface{} `json:"rule_value"`
@@ -67,6 +68,7 @@ type JobAttributes struct {
 	Active                   bool                   `json:"active"`
 	GroupID                  int                    `json:"group_id"`
 	AwsAccountId             int                    `json:"aws_account_id,omitempty"`
+	AwsAccountIds            []int                  `json:"aws_account_ids,omitempty"`
 	GoogleCloudAccountId     int                    `json:"google_cloud_account_id,omitempty"`
 	ForWorkflow              *bool                  `json:"for_workflow,omitempty"`
 	RuleType                 string                 `json:"rule_type"`
@@ -280,6 +282,7 @@ func (j *Job) UnmarshalJSON(data []byte) error {
 	j.GroupId = rj.Attributes.GroupID
 	j.ForWorkflow = rj.Attributes.ForWorkflow
 	j.AwsAccountId = rj.Attributes.AwsAccountId
+	j.AwsAccountIds = rj.Attributes.AwsAccountIds
 	j.GoogleCloudAccountId = rj.Attributes.GoogleCloudAccountId
 	j.RuleType = rj.Attributes.RuleType
 	j.RuleValue = readRuleValues(&rj.Attributes)

--- a/internal/provider/data_source_job.go
+++ b/internal/provider/data_source_job.go
@@ -38,6 +38,12 @@ func dataSourceJob() *schema.Resource {
 				Type:        schema.TypeInt,
 				Computed:    true,
 			},
+			"aws_account_ids": {
+				Description: "AWS account IDs",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+			},
 			"rule_type": {
 				Description: "Trigger type",
 				Type:        schema.TypeString,
@@ -79,6 +85,15 @@ func dataSourceJob() *schema.Resource {
 				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: aws.AuthorizeSecurityGroupIngressyActionValueFields(),
+				},
+			},
+			"bulk_stop_instances_action_value": {
+				Description: "\"EC2: Stop ALL instances\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: aws.BulkStopInstancesActionValueFields(),
 				},
 			},
 			"change_rds_cluster_instance_class_action_value": {
@@ -515,6 +530,7 @@ func dataSourceJobRead(ctx context.Context, d *schema.ResourceData, m interface{
 	d.Set("name", job.Name)
 	d.Set("group_id", job.GroupId)
 	d.Set("aws_account_id", job.AwsAccountId)
+	d.Set("aws_account_ids", utils.FlattenIntList(job.AwsAccountIds))
 
 	d.Set("rule_type", job.RuleType)
 

--- a/internal/provider/resource_job.go
+++ b/internal/provider/resource_job.go
@@ -50,6 +50,12 @@ func resourceJob() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 			},
+			"aws_account_ids": {
+				Description: "AWS account IDs",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+			},
 			"google_cloud_account_id": {
 				Description: "Google Cloud account ID",
 				Type:        schema.TypeInt,
@@ -101,6 +107,15 @@ func resourceJob() *schema.Resource {
 				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: aws.AuthorizeSecurityGroupIngressyActionValueFields(),
+				},
+			},
+			"bulk_stop_instances_action_value": {
+				Description: "\"EC2: Stop ALL instances\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: aws.BulkStopInstancesActionValueFields(),
 				},
 			},
 			"change_rds_cluster_instance_class_action_value": {
@@ -301,24 +316,24 @@ func resourceJob() *schema.Resource {
 					Schema: gcp.GoogleComputeInsertMachineImageActionValueFields(),
 				},
 			},
-      "google_compute_start_vm_instances_action_value": {
-        Description: "\"Compute Engine: start vm instances\" action value",
-        Type:        schema.TypeList,
-        Optional:    true,
-        MaxItems:    1,
-        Elem: &schema.Resource{
-          Schema: gcp.GoogleComputeStartVmInstancesActionValueFields(),
-        },
-      },
-      "google_compute_stop_vm_instances_action_value": {
-        Description: "\"Compute Engine: stop vm instances\" action value",
-        Type:        schema.TypeList,
-        Optional:    true,
-        MaxItems:    1,
-        Elem: &schema.Resource{
-          Schema: gcp.GoogleComputeStopVmInstancesActionValueFields(),
-        },
-      },
+			"google_compute_start_vm_instances_action_value": {
+				Description: "\"Compute Engine: start vm instances\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: gcp.GoogleComputeStartVmInstancesActionValueFields(),
+				},
+			},
+			"google_compute_stop_vm_instances_action_value": {
+				Description: "\"Compute Engine: stop vm instances\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: gcp.GoogleComputeStopVmInstancesActionValueFields(),
+				},
+			},
 			"invoke_lambda_function_action_value": {
 				Description: "\"Lambda: Invoke lambda function\" action value",
 				Type:        schema.TypeList,
@@ -570,6 +585,10 @@ func resourceJobCreate(ctx context.Context, d *schema.ResourceData, m interface{
 		job.AwsAccountId = v.(int)
 	}
 
+	if v, ok := d.GetOk("aws_account_ids"); ok && len(v.([]interface{})) > 0 {
+		job.AwsAccountIds = utils.ExpandIntList(v.([]interface{}))
+	}
+
 	if v, ok := d.GetOk("google_cloud_account_id"); ok {
 		job.GoogleCloudAccountId = v.(int)
 	}
@@ -640,6 +659,7 @@ func resourceJobRead(ctx context.Context, d *schema.ResourceData, m interface{})
 	d.Set("name", job.Name)
 	d.Set("group_id", job.GroupId)
 	d.Set("aws_account_id", job.AwsAccountId)
+	d.Set("aws_account_ids", utils.FlattenIntList(job.AwsAccountIds))
 	d.Set("google_cloud_account_id", job.GoogleCloudAccountId)
 	d.Set("for_workflow", job.ForWorkflow)
 
@@ -691,6 +711,10 @@ func resourceJobUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 
 	if d.HasChange("aws_account_id") {
 		job.AwsAccountId = d.Get("aws_account_id").(int)
+	}
+
+	if d.HasChange("aws_account_ids") {
+		job.AwsAccountIds = utils.ExpandIntList(d.Get("aws_account_ids").([]interface{}))
 	}
 
 	if d.HasChange("google_cloud_account_id") {

--- a/internal/provider/resource_job_test.go
+++ b/internal/provider/resource_job_test.go
@@ -306,6 +306,40 @@ func TestAccCloudAutomatorJob_AuthorizeSecurityGroupIngressAction(t *testing.T) 
 	})
 }
 
+func TestAccCloudAutomatorJob_BulkStopInstancesAction(t *testing.T) {
+	resourceName := "cloudautomator_job.test"
+	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
+	postProcessId := acctest.TestPostProcessId()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckCloudAutomatorJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudAutomatorJobConfigBulkStopInstancesAction(jobName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudAutomatorJobExists(testAccProviders["cloudautomator"], resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", jobName),
+					resource.TestCheckResourceAttr(
+						resourceName, "action_type", "bulk_stop_instances"),
+					resource.TestCheckResourceAttr(
+						resourceName, "bulk_stop_instances_action_value.0.exclude_by_tag", "true"),
+					resource.TestCheckResourceAttr(
+						resourceName, "bulk_stop_instances_action_value.0.exclude_by_tag_key", "env"),
+					resource.TestCheckResourceAttr(
+						resourceName, "bulk_stop_instances_action_value.0.exclude_by_tag_value", "production"),
+					resource.TestCheckResourceAttr(
+						resourceName, "completed_post_process_id.0", postProcessId),
+					resource.TestCheckResourceAttr(
+						resourceName, "failed_post_process_id.0", postProcessId),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudAutomatorJob_ChangeRdsClusterInstanceClassAction(t *testing.T) {
 	resourceName := "cloudautomator_job.test"
 	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
@@ -1119,79 +1153,79 @@ func TestAccCloudAutomatorJob_GoogleComputeInsertMachineImageAction(t *testing.T
 }
 
 func TestAccCloudAutomatorJob_GoogleComputeStartVmInstancesAction(t *testing.T) {
-  resourceName := "cloudautomator_job.test"
-  jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
-  postProcessId := acctest.TestPostProcessId()
+	resourceName := "cloudautomator_job.test"
+	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
+	postProcessId := acctest.TestPostProcessId()
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:          func() { testAccPreCheck(t) },
-    ProviderFactories: testAccProviderFactories,
-    CheckDestroy:      testAccCheckCloudAutomatorJobDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: testAccCheckCloudAutomatorJobConfigGoogleComputeStartVmInstancesAction(jobName),
-        Check: resource.ComposeTestCheckFunc(
-          testAccCheckCloudAutomatorJobExists(testAccProviders["cloudautomator"], resourceName),
-          resource.TestCheckResourceAttr(
-            resourceName, "name", jobName),
-          resource.TestCheckResourceAttr(
-            resourceName, "action_type", "google_compute_start_vm_instances"),
-          resource.TestCheckResourceAttr(
-            resourceName, "google_compute_start_vm_instances_action_value.0.region", "asia-northeast1"),
-          resource.TestCheckResourceAttr(
-            resourceName, "google_compute_start_vm_instances_action_value.0.project_id", "example-project"),
-          resource.TestCheckResourceAttr(
-            resourceName, "google_compute_start_vm_instances_action_value.0.specify_vm_instance", "label"),
-          resource.TestCheckResourceAttr(
-            resourceName, "google_compute_start_vm_instances_action_value.0.vm_instance_label_key", "env"),
-          resource.TestCheckResourceAttr(
-            resourceName, "google_compute_start_vm_instances_action_value.0.vm_instance_label_value", "develop"),
-          resource.TestCheckResourceAttr(
-            resourceName, "completed_post_process_id.0", postProcessId),
-          resource.TestCheckResourceAttr(
-            resourceName, "failed_post_process_id.0", postProcessId),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckCloudAutomatorJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudAutomatorJobConfigGoogleComputeStartVmInstancesAction(jobName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudAutomatorJobExists(testAccProviders["cloudautomator"], resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", jobName),
+					resource.TestCheckResourceAttr(
+						resourceName, "action_type", "google_compute_start_vm_instances"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_start_vm_instances_action_value.0.region", "asia-northeast1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_start_vm_instances_action_value.0.project_id", "example-project"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_start_vm_instances_action_value.0.specify_vm_instance", "label"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_start_vm_instances_action_value.0.vm_instance_label_key", "env"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_start_vm_instances_action_value.0.vm_instance_label_value", "develop"),
+					resource.TestCheckResourceAttr(
+						resourceName, "completed_post_process_id.0", postProcessId),
+					resource.TestCheckResourceAttr(
+						resourceName, "failed_post_process_id.0", postProcessId),
+				),
+			},
+		},
+	})
 }
 
 func TestAccCloudAutomatorJob_GoogleComputeStopVmInstancesAction(t *testing.T) {
-  resourceName := "cloudautomator_job.test"
-  jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
-  postProcessId := acctest.TestPostProcessId()
+	resourceName := "cloudautomator_job.test"
+	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
+	postProcessId := acctest.TestPostProcessId()
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:          func() { testAccPreCheck(t) },
-    ProviderFactories: testAccProviderFactories,
-    CheckDestroy:      testAccCheckCloudAutomatorJobDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: testAccCheckCloudAutomatorJobConfigGoogleComputeStopVmInstancesAction(jobName),
-        Check: resource.ComposeTestCheckFunc(
-          testAccCheckCloudAutomatorJobExists(testAccProviders["cloudautomator"], resourceName),
-          resource.TestCheckResourceAttr(
-            resourceName, "name", jobName),
-          resource.TestCheckResourceAttr(
-            resourceName, "action_type", "google_compute_stop_vm_instances"),
-          resource.TestCheckResourceAttr(
-            resourceName, "google_compute_stop_vm_instances_action_value.0.region", "asia-northeast1"),
-          resource.TestCheckResourceAttr(
-            resourceName, "google_compute_stop_vm_instances_action_value.0.project_id", "example-project"),
-          resource.TestCheckResourceAttr(
-            resourceName, "google_compute_stop_vm_instances_action_value.0.specify_vm_instance", "label"),
-          resource.TestCheckResourceAttr(
-            resourceName, "google_compute_stop_vm_instances_action_value.0.vm_instance_label_key", "env"),
-          resource.TestCheckResourceAttr(
-            resourceName, "google_compute_stop_vm_instances_action_value.0.vm_instance_label_value", "develop"),
-          resource.TestCheckResourceAttr(
-            resourceName, "completed_post_process_id.0", postProcessId),
-          resource.TestCheckResourceAttr(
-            resourceName, "failed_post_process_id.0", postProcessId),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckCloudAutomatorJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudAutomatorJobConfigGoogleComputeStopVmInstancesAction(jobName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudAutomatorJobExists(testAccProviders["cloudautomator"], resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", jobName),
+					resource.TestCheckResourceAttr(
+						resourceName, "action_type", "google_compute_stop_vm_instances"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_stop_vm_instances_action_value.0.region", "asia-northeast1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_stop_vm_instances_action_value.0.project_id", "example-project"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_stop_vm_instances_action_value.0.specify_vm_instance", "label"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_stop_vm_instances_action_value.0.vm_instance_label_key", "env"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_stop_vm_instances_action_value.0.vm_instance_label_value", "develop"),
+					resource.TestCheckResourceAttr(
+						resourceName, "completed_post_process_id.0", postProcessId),
+					resource.TestCheckResourceAttr(
+						resourceName, "failed_post_process_id.0", postProcessId),
+				),
+			},
+		},
+	})
 }
 
 func TestAccCloudAutomatorJob_InvokeLambdaFunctionAction(t *testing.T) {
@@ -2373,6 +2407,27 @@ resource "cloudautomator_job" "test" {
 }`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
 }
 
+func testAccCheckCloudAutomatorJobConfigBulkStopInstancesAction(rName string) string {
+	return fmt.Sprintf(`
+resource "cloudautomator_job" "test" {
+	name = "%s"
+	group_id = "%s"
+	aws_account_ids = [%s]
+
+	rule_type = "webhook"
+
+	action_type = "bulk_stop_instances"
+	bulk_stop_instances_action_value {
+		exclude_by_tag = true
+		exclude_by_tag_key = "env"
+		exclude_by_tag_value = "production"
+	}
+
+	completed_post_process_id = [%s]
+	failed_post_process_id = [%s]
+}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}
+
 func testAccCheckCloudAutomatorJobConfigChangeRdsClusterInstanceClassAction(rName string) string {
 	return fmt.Sprintf(`
 resource "cloudautomator_job" "test" {
@@ -2844,7 +2899,7 @@ resource "cloudautomator_job" "test" {
 }
 
 func testAccCheckCloudAutomatorJobConfigGoogleComputeStartVmInstancesAction(rName string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "cloudautomator_job" "test" {
   name = "%s"
   group_id = "%s"
@@ -2866,7 +2921,7 @@ resource "cloudautomator_job" "test" {
 }
 
 func testAccCheckCloudAutomatorJobConfigGoogleComputeStopVmInstancesAction(rName string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "cloudautomator_job" "test" {
   name = "%s"
   group_id = "%s"

--- a/internal/schemes/job/aws/ec2.go
+++ b/internal/schemes/job/aws/ec2.go
@@ -49,6 +49,26 @@ func AuthorizeSecurityGroupIngressyActionValueFields() map[string]*schema.Schema
 	}
 }
 
+func BulkStopInstancesActionValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"exclude_by_tag": {
+			Description: "Whether to exclude instances with the specified tag from the target",
+			Type:        schema.TypeBool,
+			Required:    true,
+		},
+		"exclude_by_tag_key": {
+			Description: "Tag key used to exclude instances from the target",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"exclude_by_tag_value": {
+			Description: "Tag value used to exclude instances from the target",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+	}
+}
+
 func ChangeInstanceTypeActionValueFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"region": {


### PR DESCRIPTION
「EC2: インスタンスをすべて停止」アクションに対応しました。

**resource example**

```tf
resource "cloudautomator_job" "example-stop-ecs-tasks" {
  name            = "example-bulk-stop-instances-job"
  group_id        = 10
  aws_account_ids = [20]

  rule_type = "immediate_execution"

  action_type = "bulk_stop_instances"
  bulk_stop_instances_action_value {
    exclude_by_tag       = true
    exclude_by_tag_key   = "env"
    exclude_by_tag_value = "develop"
  }
}
```