### PR TITLE
「S3: バケットをバックアップ」アクションに対応した

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,6 +10,9 @@ on:
       ca_test_api_key:
         description: "CA_TEST_API_KEY"
         required: true
+      ca_test_aws_account_number:
+        description: "CA_TEST_AWS_ACCOUNT_NUMBER"
+        required: true
       ca_test_aws_account_id:
         description: "CA_TEST_AWS_ACCOUNT_ID"
         required: true
@@ -19,14 +22,14 @@ on:
       ca_test_group_id:
         description: "CA_TEST_GROUP_ID"
         required: true
-      ca_test_sqs_aws_account_id:
-        description: "CA_TEST_SQS_AWS_ACCOUNT_ID"
+      ca_test_region:
+        description: "CA_TEST_REGION"
+        required: true
+      ca_test_s3_bucket_name:
+        description: "CA_TEST_S3_BUCKET_NAME"
         required: true
       ca_test_sqs_queue:
         description: "CA_TEST_SQS_QUEUE"
-        required: true
-      ca_test_sqs_region:
-        description: "CA_TEST_SQS_REGION"
         required: true
       ca_test_post_process_id:
         description: "CA_TEST_POST_PROCESS_ID"
@@ -66,12 +69,13 @@ jobs:
         env:
           TF_ACC: "1"
           CA_TEST_API_KEY: ${{github.event.inputs.ca_test_api_key}}
+          CA_TEST_AWS_ACCOUNT_NUMBER: ${{github.event.inputs.ca_test_aws_account_number}}
           CA_TEST_AWS_ACCOUNT_ID: ${{github.event.inputs.ca_test_aws_account_id}}
           CA_TEST_GOOGLE_CLOUD_ACCOUNT_ID: ${{github.event.inputs.ca_test_google_cloud_account_id}}
           CA_TEST_GROUP_ID: ${{github.event.inputs.ca_test_group_id}}
-          CA_TEST_SQS_AWS_ACCOUNT_ID: ${{github.event.inputs.ca_test_sqs_aws_account_id}}
+          CA_TEST_REGION: ${{github.event.inputs.ca_test_region}}
+          CA_TEST_S3_BUCKET_NAME: ${{github.event.inputs.ca_test_s3_bucket_name}}
           CA_TEST_SQS_QUEUE: ${{github.event.inputs.ca_test_sqs_queue}}
-          CA_TEST_SQS_REGION: ${{github.event.inputs.ca_test_sqs_region}}
           CA_TEST_POST_PROCESS_ID: ${{github.event.inputs.ca_test_post_process_id}}
         run: |
           make testacc

--- a/examples/resources/job/action/s3_start_backup_job/main.tf
+++ b/examples/resources/job/action/s3_start_backup_job/main.tf
@@ -1,0 +1,43 @@
+# ----------------------------------------------------------
+# - アクション
+#   - S3: バケットをバックアップ
+# - アクションの設定
+#   - 対象のバケットとバックアップボールトが存在するAWSリージョン
+#     - ap-northeast-1
+#   - 対象のバケットの名前
+#     - test-bucket
+#   - バックアップボールトの名前
+#     - TestBackup
+#   - ライフサイクル-
+#     - 7日
+#   - バックアップ取得時に使うIAMロールのARN
+#     - arn:aws:iam::123456789012:role/RoleForBackup
+#   - 作成した復旧ポイントに割り当てるタグの配列
+#     - key1: value1
+#     - key2: value2
+# ----------------------------------------------------------
+
+resource "cloudautomator_job" "example-s3-start-backup-job-job" {
+  name           = "example-s3-start-backup-job-job"
+  group_id       = 10
+  aws_account_id = 20
+
+  rule_type = "webhook"
+
+  action_type = "s3_start_backup_job"
+  s3_start_backup_job_action_value {
+    region                      = "ap-northeast-1"
+    bucket_name                 = "test-bucket"
+    backup_vault_name           = "TestBackup"
+    lifecycle_delete_after_days = 7
+    iam_role_arn                = "arn:aws:iam::123456789012:role/RoleForBackup"
+    additional_tags {
+      key   = "key1"
+      value = "value1"
+    }
+    additional_tags {
+      key   = "key2"
+      value = "value2"
+    }
+  }
+}

--- a/internal/acctest/envvar.go
+++ b/internal/acctest/envvar.go
@@ -8,20 +8,24 @@ func TestGroupId() string {
 	return os.Getenv("CA_TEST_GROUP_ID")
 }
 
-func TestAwsAccountId() string {
-	return os.Getenv("CA_TEST_AWS_ACCOUNT_ID")
+func TestAwsAccountNumber() string {
+	return os.Getenv("CA_TEST_AWS_ACCOUNT_NUMBER")
 }
 
-func TestSqsAwsAccountId() string {
-	return os.Getenv("CA_TEST_SQS_AWS_ACCOUNT_ID")
+func TestAwsAccountId() string {
+	return os.Getenv("CA_TEST_AWS_ACCOUNT_ID")
 }
 
 func TestGoogleCloudAccountId() string {
 	return os.Getenv("CA_TEST_GOOGLE_CLOUD_ACCOUNT_ID")
 }
 
-func TestSqsRegion() string {
-	return os.Getenv("CA_TEST_SQS_REGION")
+func TestRegion() string {
+	return os.Getenv("CA_TEST_REGION")
+}
+
+func TestS3BucketName() string {
+	return os.Getenv("CA_TEST_S3_BUCKET_NAME")
 }
 
 func TestSqsQueue() string {

--- a/internal/provider/data_source_job.go
+++ b/internal/provider/data_source_job.go
@@ -384,6 +384,15 @@ func dataSourceJob() *schema.Resource {
 					Schema: aws.RunEcsTasksFargateActionValueFields(),
 				},
 			},
+			"s3_start_backup_job_action_value": {
+				Description: "\"S3: Backup\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: aws.S3StartBackupJobActionValueFields(),
+				},
+			},
 			"send_command_action_value": {
 				Description: "\"EC2: Send command on instance\" action value",
 				Type:        schema.TypeList,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -8,11 +8,12 @@ import (
 )
 
 const testApiKeyEnvName = "CA_TEST_API_KEY"
+const testAwsAccountNumberEnvName = "CA_TEST_AWS_ACCOUNT_NUMBER"
 const testAwsAccountIdEnvName = "CA_TEST_AWS_ACCOUNT_ID"
 const testGoogleCloudAccountIdEnvName = "CA_TEST_GOOGLE_CLOUD_ACCOUNT_ID"
 const testGroupIdEnvName = "CA_TEST_GROUP_ID"
-const testSqsAwsAccountIdEnvName = "CA_TEST_SQS_AWS_ACCOUNT_ID"
-const testSqsRegionEnvName = "CA_TEST_SQS_REGION"
+const testRegionEnvName = "CA_TEST_REGION"
+const TestS3BucketNameEnvName = "CA_TEST_S3_BUCKET_NAME"
 const testSqsQueueEnvName = "CA_TEST_SQS_QUEUE"
 const testPostProcessIdEnvName = "CA_TEST_POST_PROCESS_ID"
 
@@ -53,16 +54,16 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatalf("%s must be set for acceptance tests", testAwsAccountIdEnvName)
 	}
 
+	if err := os.Getenv(testAwsAccountNumberEnvName); err == "" {
+		t.Fatalf("%s must be set for acceptance tests", testAwsAccountNumberEnvName)
+	}
+
 	if err := os.Getenv(testGoogleCloudAccountIdEnvName); err == "" {
 		t.Fatalf("%s must be set for acceptance tests", testGoogleCloudAccountIdEnvName)
 	}
 
-	if err := os.Getenv(testSqsAwsAccountIdEnvName); err == "" {
-		t.Fatalf("%s must be set for acceptance tests", testSqsAwsAccountIdEnvName)
-	}
-
-	if err := os.Getenv(testSqsRegionEnvName); err == "" {
-		t.Fatalf("%s must be set for acceptance tests", testSqsRegionEnvName)
+	if err := os.Getenv(testRegionEnvName); err == "" {
+		t.Fatalf("%s must be set for acceptance tests", testRegionEnvName)
 	}
 
 	if err := os.Getenv(testSqsQueueEnvName); err == "" {

--- a/internal/provider/resource_post_process_test.go
+++ b/internal/provider/resource_post_process_test.go
@@ -95,7 +95,7 @@ func TestAccCloudAutomatorPostProcess_Sqs(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName, "shared_by_group", "false"),
 					resource.TestCheckResourceAttr(
-						resourceName, "sqs_parameters.0.sqs_aws_account_id", acctest.TestSqsAwsAccountId()),
+						resourceName, "sqs_parameters.0.sqs_aws_account_id", acctest.TestAwsAccountId()),
 					resource.TestCheckResourceAttr(
 						resourceName, "sqs_parameters.0.sqs_queue", "test-queue"),
 					resource.TestCheckResourceAttr(

--- a/internal/schemes/job/aws/s3.go
+++ b/internal/schemes/job/aws/s3.go
@@ -1,0 +1,52 @@
+package schemes
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func S3StartBackupJobActionValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"region": {
+			Description: "AWS Region in which the target resource resides",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"bucket_name": {
+			Description: "Name of the S3 bucket to store the backup",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"backup_vault_name": {
+			Description: "Name of the backup vault to store the backup",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"lifecycle_delete_after_days": {
+			Description: "Number of days to keep the backup",
+			Type:        schema.TypeInt,
+			Optional:    true,
+		},
+		"iam_role_arn": {
+			Description: "ARN of the IAM role to use for the backup",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"additional_tags": {
+			Description: "Additional tags to be added to the backup",
+			Type:        schema.TypeSet,
+			Optional:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"key": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"value": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
「S3: バケットをバックアップ」アクションに対応しました。

**resource example**

```tf
resource "cloudautomator_job" "example-s3-start-backup-job-job" {
  name           = "example-s3-start-backup-job-job"
  group_id       = 10
  aws_account_id = 20

  rule_type = "webhook"

  action_type = "s3_start_backup_job"
  s3_start_backup_job_action_value {
    region                      = "ap-northeast-1"
    bucket_name                 = "test-bucket"
    backup_vault_name           = "TestBackup"
    lifecycle_delete_after_days = 7
    iam_role_arn                = "arn:aws:iam::123456789012:role/RoleForBackup"
    additional_tags {
      key   = "key1"
      value = "value1"
    }
    additional_tags {
      key   = "key2"
      value = "value2"
    }
  }
}
```