### PR TITLE
「IAM: ユーザーにポリシーをアタッチ」アクションに対応した

### DIFF
--- a/examples/resources/cloudautomator_job/action/attach_user_policy/main.tf
+++ b/examples/resources/cloudautomator_job/action/attach_user_policy/main.tf
@@ -1,0 +1,23 @@
+# ----------------------------------------------------------
+# - アクション
+#   - IAM: ユーザーにポリシーをアタッチ
+# - アクションの設定
+#   - ユーザー名
+#     - example-user
+#   - IAMポリシーARN
+#     - arn:aws:iam::123456789012:policy/example-policy
+# ----------------------------------------------------------
+
+resource "cloudautomator_job" "example-attach-user-policy-job" {
+  name           = "example-attach-user-policy-job"
+  group_id       = 10
+  aws_account_id = 20
+
+  rule_type = "immediate_execution"
+
+  action_type = "attach_user_policy"
+  attach_user_policy_action_value {
+    user_name  = "example-user"
+    policy_arn = "arn:aws:iam::123456789012:policy/example-policy"
+  }
+}

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -85,6 +85,7 @@ type JobAttributes struct {
 }
 
 var TRACE_STATUS_NOT_SUPPORTED_ACTION_TYPES = []string{
+	"attach_user_policy",
 	"authorize_security_group_ingress",
 	"copy_rds_cluster_snapshot",
 	"create_fsx_backup",

--- a/internal/provider/data_source_job.go
+++ b/internal/provider/data_source_job.go
@@ -78,6 +78,15 @@ func dataSourceJob() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"attach_user_policy_action_value": {
+				Description: "\"IAM: Attach Policy to IAM User\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: aws.AttachUserPolicyActionValueFields(),
+				},
+			},
 			"authorize_security_group_ingress_action_value": {
 				Description: "\"EC2: Authorize security group ingress\" action value",
 				Type:        schema.TypeList,

--- a/internal/provider/resource_job.go
+++ b/internal/provider/resource_job.go
@@ -100,6 +100,15 @@ func resourceJob() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 			},
+			"attach_user_policy_action_value": {
+				Description: "\"IAM: Attach Policy to IAM User\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: aws.AttachUserPolicyActionValueFields(),
+				},
+			},
 			"authorize_security_group_ingress_action_value": {
 				Description: "\"EC2: Authorize security group ingress\" action value",
 				Type:        schema.TypeList,

--- a/internal/provider/resource_job_test.go
+++ b/internal/provider/resource_job_test.go
@@ -264,6 +264,38 @@ func TestAccCloudAutomatorJob_AmazonSnsRule(t *testing.T) {
 	})
 }
 
+func TestAccCloudAutomatorJob_AttachUserPolicyAction(t *testing.T) {
+	resourceName := "cloudautomator_job.test"
+	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
+	postProcessId := acctest.TestPostProcessId()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckCloudAutomatorJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudAutomatorJobConfigAttachUserPolicyAction(jobName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudAutomatorJobExists(testAccProviders["cloudautomator"], resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", jobName),
+					resource.TestCheckResourceAttr(
+						resourceName, "action_type", "attach_user_policy"),
+					resource.TestCheckResourceAttr(
+						resourceName, "attach_user_policy_action_value.0.user_name", "example-user"),
+					resource.TestCheckResourceAttr(
+						resourceName, "attach_user_policy_action_value.0.policy_arn", "arn:aws:iam::123456789012:policy/example-policy"),
+					resource.TestCheckResourceAttr(
+						resourceName, "completed_post_process_id.0", postProcessId),
+					resource.TestCheckResourceAttr(
+						resourceName, "failed_post_process_id.0", postProcessId),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudAutomatorJob_AuthorizeSecurityGroupIngressAction(t *testing.T) {
 	resourceName := "cloudautomator_job.test"
 	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
@@ -2526,6 +2558,25 @@ resource "cloudautomator_job" "test" {
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]
 }`, rName, acctest.TestGroupId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}
+
+func testAccCheckCloudAutomatorJobConfigAttachUserPolicyAction(rName string) string {
+	return fmt.Sprintf(`
+resource "cloudautomator_job" "test" {
+	name = "%s"
+	group_id = "%s"
+	aws_account_id = "%s"
+
+	rule_type = "webhook"
+
+	action_type = "attach_user_policy"
+	attach_user_policy_action_value {
+		user_name = "example-user"
+		policy_arn = "arn:aws:iam::123456789012:policy/example-policy"
+	}
+	completed_post_process_id = [%s]
+	failed_post_process_id = [%s]
+}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
 }
 
 func testAccCheckCloudAutomatorJobConfigAuthorizeSecurityGroupIngressAction(rName string) string {

--- a/internal/schemes/job/aws/iam.go
+++ b/internal/schemes/job/aws/iam.go
@@ -1,0 +1,20 @@
+package schemes
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func AttachUserPolicyActionValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"user_name": {
+			Description: "Name of the user to attach the policy to",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"policy_arn": {
+			Description: "ARN of the policy to attach",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+	}
+}


### PR DESCRIPTION
「IAM: ユーザーにポリシーをアタッチ」アクションに対応しました。

**resource example**

```tf
resource "cloudautomator_job" "example-attach-user-policy-job" {
  name           = "example-attach-user-policy-job"
  group_id       = 10
  aws_account_id = 20

  rule_type = "immediate_execution"

  action_type = "attach_user_policy"
  attach_user_policy_action_value {
    user_name  = "example-user"
    policy_arn = "arn:aws:iam::123456789012:policy/example-policy"
  }
}
```