### PR TITLE
「DynamoDB: テーブルをバックアップ」アクションに対応した

### DIFF
--- a/examples/resources/cloudautomator_job/action/dynamodb_start_backup_job/main.tf
+++ b/examples/resources/cloudautomator_job/action/dynamodb_start_backup_job/main.tf
@@ -1,0 +1,84 @@
+# ----------------------------------------------------------
+# - アクション
+#   - DynamoDB: テーブルをバックアップ
+# - アクションの設定
+#   - 対象のテーブルとバックアップボールトが存在するAWSリージョン
+#     - ap-northeast-1
+#   - 対象のDynamoDBテーブルの名前
+#     - example-table
+#   - 対象のバックアップボールトの名前
+#     - example-backup
+#   - バックアップの保持期間(日数)
+#     - 無期限
+#   - バックアップ取得時に使うIAMロールのARN
+#     - arn:aws:iam::123456789012:role/RoleForBackup
+# ----------------------------------------------------------
+
+resource "cloudautomator_job" "example-dynamodb-start-backup-job" {
+  name           = "example-dynamodb-start-backup-job"
+  group_id       = 10
+  aws_account_id = 20
+
+  rule_type = "immediate_execution"
+
+  action_type = "dynamodb_start_backup_job"
+  dynamodb_start_backup_job_action_value {
+    region                      = "ap-northeast-1"
+    dynamodb_table_name         = "example-table"
+    backup_vault_name           = "example-backup"
+    lifecycle_delete_after_days = null
+    iam_role_arn                = "arn:aws:iam::123456789012:role/RoleForBackup"
+  }
+}
+
+# ----------------------------------------------------------
+# - アクション
+#   - DynamoDB: テーブルをバックアップ
+# - アクションの設定
+#   - 対象のテーブルとバックアップボールトが存在するAWSリージョン
+#     - ap-northeast-1
+#   - 対象のDynamoDBテーブルの名前
+#     - example-table
+#   - バックアップの保持期間(日数)
+#     - 7
+#   - 対象のバックアップボールトの名前
+#     - example-backup
+#   - バックアップ取得時に使うIAMロールのARN
+#     - arn:aws:iam::123456789012:role/RoleForBackup
+#   - 作成した復旧ポイントに割り当てるタグの配列
+#     - key1: value1
+#     - key2: value2
+#     - key3: value3
+# ----------------------------------------------------------
+
+resource "cloudautomator_job" "example-dynamodb-start-backup-job" {
+  name           = "example-dynamodb-start-backup-job"
+  group_id       = 10
+  aws_account_id = 20
+
+  rule_type = "immediate_execution"
+
+  action_type = "dynamodb_start_backup_job"
+  dynamodb_start_backup_job_action_value {
+    region                      = "ap-northeast-1"
+    dynamodb_table_name         = "example-table"
+    lifecycle_delete_after_days = 7
+    backup_vault_name           = "example-backup"
+    iam_role_arn                = "arn:aws:iam::123456789012:role/RoleForBackup"
+
+    additional_tags {
+      key   = "key1"
+      value = "value1"
+    }
+
+    additional_tags {
+      key   = "key2"
+      value = "value2"
+    }
+
+    additional_tags {
+      key   = "key3"
+      value = "value3"
+    }
+  }
+}

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -95,6 +95,7 @@ var TRACE_STATUS_NOT_SUPPORTED_ACTION_TYPES = []string{
 	"deregister_instances",
 	"deregister_target_instances",
 	"describe_metadata",
+	"dynamodb_start_backup_job",
 	"google_compute_insert_machine_image",
 	"google_compute_stop_vm_instances",
 	"google_compute_start_vm_instances",

--- a/internal/provider/data_source_job.go
+++ b/internal/provider/data_source_job.go
@@ -303,6 +303,15 @@ func dataSourceJob() *schema.Resource {
 					Schema: aws.DisasterRecoveryActionValueFields(),
 				},
 			},
+			"dynamodb_start_backup_job_action_value": {
+				Description: "\"DynamoDB: Backup table\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: aws.DynamodbStartBackupJobActionValueFields(),
+				},
+			},
 			"google_compute_insert_machine_image_action_value": {
 				Description: "\"Compute Engine: create machine image\" action value",
 				Type:        schema.TypeList,

--- a/internal/provider/resource_job_test.go
+++ b/internal/provider/resource_job_test.go
@@ -1172,6 +1172,56 @@ func TestAccCloudAutomatorJob_DetachUserPolicyAction(t *testing.T) {
 	})
 }
 
+func TestAccCloudAutomatorJob_DynamodbStartBackupJobAction(t *testing.T) {
+	resourceName := "cloudautomator_job.test"
+	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
+	postProcessId := acctest.TestPostProcessId()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckCloudAutomatorJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudAutomatorJobConfigDynamodbStartBackupJobAction(jobName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudAutomatorJobExists(testAccProviders["cloudautomator"], resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", jobName),
+					resource.TestCheckResourceAttr(
+						resourceName, "action_type", "dynamodb_start_backup_job"),
+					resource.TestCheckResourceAttr(
+						resourceName, "dynamodb_start_backup_job_action_value.0.region", "ap-northeast-1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "dynamodb_start_backup_job_action_value.0.dynamodb_table_name", "example-table"),
+					resource.TestCheckResourceAttr(
+						resourceName, "dynamodb_start_backup_job_action_value.0.lifecycle_delete_after_days", "7"),
+					resource.TestCheckResourceAttr(
+						resourceName, "dynamodb_start_backup_job_action_value.0.backup_vault_name", "example-vault"),
+					resource.TestCheckResourceAttr(
+						resourceName, "dynamodb_start_backup_job_action_value.0.iam_role_arn", "arn:aws:iam::123456789012:role/example-role"),
+					resource.TestCheckResourceAttr(
+						resourceName, "dynamodb_start_backup_job_action_value.0.additional_tags.0.key", "key1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "dynamodb_start_backup_job_action_value.0.additional_tags.0.value", "value1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "dynamodb_start_backup_job_action_value.0.additional_tags.1.key", "key2"),
+					resource.TestCheckResourceAttr(
+						resourceName, "dynamodb_start_backup_job_action_value.0.additional_tags.1.value", "value2"),
+					resource.TestCheckResourceAttr(
+						resourceName, "dynamodb_start_backup_job_action_value.0.additional_tags.2.key", "key3"),
+					resource.TestCheckResourceAttr(
+						resourceName, "dynamodb_start_backup_job_action_value.0.additional_tags.2.value", "value3"),
+					resource.TestCheckResourceAttr(
+						resourceName, "completed_post_process_id.0", postProcessId),
+					resource.TestCheckResourceAttr(
+						resourceName, "failed_post_process_id.0", postProcessId),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudAutomatorJob_GoogleComputeInsertMachineImageAction(t *testing.T) {
 	resourceName := "cloudautomator_job.test"
 	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
@@ -3114,6 +3164,43 @@ resource "cloudautomator_job" "test" {
 	detach_user_policy_action_value {
 		user_name = "example-user"
 		policy_arn = "arn:aws:iam::123456789012:policy/example-policy"
+	}
+	completed_post_process_id = [%s]
+	failed_post_process_id = [%s]
+}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}
+
+func testAccCheckCloudAutomatorJobConfigDynamodbStartBackupJobAction(rName string) string {
+	return fmt.Sprintf(`
+resource "cloudautomator_job" "test" {
+	name = "%s"
+	group_id = "%s"
+	aws_account_id = "%s"
+
+	rule_type = "webhook"
+
+	action_type = "dynamodb_start_backup_job"
+	dynamodb_start_backup_job_action_value {
+	  region                      = "ap-northeast-1"
+	  dynamodb_table_name         = "example-table"
+	  lifecycle_delete_after_days = 7
+	  backup_vault_name           = "example-vault"
+	  iam_role_arn                = "arn:aws:iam::123456789012:role/example-role"
+
+	  additional_tags {
+		key   = "key1"
+		value = "value1"
+	  }
+
+	  additional_tags {
+		key   = "key2"
+		value = "value2"
+	  }
+
+	  additional_tags {
+		key   = "key3"
+		value = "value3"
+	  }
 	}
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]

--- a/internal/schemes/job/aws/dynamodb.go
+++ b/internal/schemes/job/aws/dynamodb.go
@@ -1,0 +1,52 @@
+package schemes
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DynamodbStartBackupJobActionValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"region": {
+			Description: "AWS Region",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"dynamodb_table_name": {
+			Description: "Name of the DynamoDB table",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"lifecycle_delete_after_days": {
+			Description: "Number of days to hold recovery point",
+			Type:        schema.TypeInt,
+			Optional:    true,
+		},
+		"backup_vault_name": {
+			Description: "Backup Vault Name",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"iam_role_arn": {
+			Description: "IAM Role ARN",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"additional_tags": {
+			Description: "Array of tags to be added to the recovery point",
+			Type:        schema.TypeSet,
+			Optional:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"key": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"value": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
「DynamoDB: テーブルをバックアップ」アクションに対応しました。

**resource example**

```tf
# ----------------------------------------------------------
# - アクション
#   - DynamoDB: テーブルをバックアップ
# - アクションの設定
#   - 対象のテーブルとバックアップボールトが存在するAWSリージョン
#     - ap-northeast-1
#   - 対象のDynamoDBテーブルの名前
#     - example-table
#   - 対象のバックアップボールトの名前
#     - example-backup
#   - バックアップの保持期間(日数)
#     - 無期限
#   - バックアップ取得時に使うIAMロールのARN
#     - arn:aws:iam::123456789012:role/RoleForBackup
# ----------------------------------------------------------

resource "cloudautomator_job" "example-dynamodb-start-backup-job" {
  name           = "example-dynamodb-start-backup-job"
  group_id       = 10
  aws_account_id = 20

  rule_type = "immediate_execution"

  action_type = "dynamodb_start_backup_job"
  dynamodb_start_backup_job_action_value {
    region                      = "ap-northeast-1"
    dynamodb_table_name         = "example-table"
    backup_vault_name           = "example-backup"
    lifecycle_delete_after_days = null
    iam_role_arn                = "arn:aws:iam::123456789012:role/RoleForBackup"
  }
}

# ----------------------------------------------------------
# - アクション
#   - DynamoDB: テーブルをバックアップ
# - アクションの設定
#   - 対象のテーブルとバックアップボールトが存在するAWSリージョン
#     - ap-northeast-1
#   - 対象のDynamoDBテーブルの名前
#     - example-table
#   - バックアップの保持期間(日数)
#     - 7
#   - 対象のバックアップボールトの名前
#     - example-backup
#   - バックアップ取得時に使うIAMロールのARN
#     - arn:aws:iam::123456789012:role/RoleForBackup
#   - 作成した復旧ポイントに割り当てるタグの配列
#     - key1: value1
#     - key2: value2
#     - key3: value3
# ----------------------------------------------------------

resource "cloudautomator_job" "example-dynamodb-start-backup-job" {
  name           = "example-dynamodb-start-backup-job"
  group_id       = 10
  aws_account_id = 20

  rule_type = "immediate_execution"

  action_type = "dynamodb_start_backup_job"
  dynamodb_start_backup_job_action_value {
    region                      = "ap-northeast-1"
    dynamodb_table_name         = "example-table"
    lifecycle_delete_after_days = 7
    backup_vault_name           = "example-backup"
    iam_role_arn                = "arn:aws:iam::123456789012:role/RoleForBackup"

    additional_tags {
      key   = "key1"
      value = "value1"
    }

    additional_tags {
      key   = "key2"
      value = "value2"
    }

    additional_tags {
      key   = "key3"
      value = "value3"
    }
  }
}

```