### PR TITLE
SNSトリガーの amazon_sns_token の値を読み取れるように変更した

### DIFF
--- a/internal/provider/resource_job.go
+++ b/internal/provider/resource_job.go
@@ -478,6 +478,16 @@ func resourceJob() *schema.Resource {
 					Schema: aws.SendCommandActionValueFields(),
 				},
 			},
+			"amazon_sns_rule_value": {
+				Description: "SNS trigger value",
+				Type:        schema.TypeList,
+				Computed:    true,
+				MaxItems:    1,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: schemes.AmazonSnsRuleValueFields(),
+				},
+			},
 			"start_instances_action_value": {
 				Description: "\"EC2: Start instance\" action value",
 				Type:        schema.TypeList,
@@ -729,7 +739,7 @@ func resourceJobRead(ctx context.Context, d *schema.ResourceData, m interface{})
 
 	d.Set("rule_type", job.RuleType)
 	switch job.RuleType {
-	case "cron", "schedule", "sqs_v2", "webhook":
+	case "cron", "schedule", "amazon_sns", "sqs_v2", "webhook":
 		ruleValueBlockName := fmt.Sprintf("%s_rule_value", job.RuleType)
 		if err := d.Set(ruleValueBlockName, []interface{}{job.RuleValue}); err != nil {
 			diags = append(diags, diag.FromErr(err)...)

--- a/internal/schemes/job/rule_value.go
+++ b/internal/schemes/job/rule_value.go
@@ -120,6 +120,21 @@ func ScheduleRuleValueFields() map[string]*schema.Schema {
 	}
 }
 
+func AmazonSnsRuleValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"amazon_sns_token": {
+			Description: "Amazon SNS token",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"time_zone": {
+			Description: "Time zone",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+	}
+}
+
 func SqsV2RuleValueFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"sqs_aws_account_id": {


### PR DESCRIPTION
SNSトリガージョブの `amazon_sns_token` の値を読み取れるように変更しました。

```tf
resource "cloudautomator_job" "sns-job" {
  name           = "example-sns-job"
  group_id       = 123
  aws_account_id = 456

  rule_type = "amazon_sns"

  action_type = "delay"
  delay_action_value {
    delay_minutes = 1
  }
}

output "amazon_sns_token" {
  value = cloudautomator_job.sns-job.amazon_sns_rule_value[0].amazon_sns_token
}
```