### PR TITLE
ユーザーが知る必要のない schedule_trigger_setting_id パラメータを削除するようにした

### DIFF
--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -226,6 +226,7 @@ func readRuleValues(rawJob *JobAttributes) map[string]interface{} {
 		delete(ruleValue, "next_occurrence")
 	case "schedule":
 		delete(ruleValue, "next_schedule")
+		delete(ruleValue, "schedule_trigger_setting_id")
 	case "sqs_v2":
 		awsAccountId, _ := strconv.Atoi(ruleValue["aws_account_id"].(string))
 		ruleValue["sqs_aws_account_id"] = awsAccountId


### PR DESCRIPTION
ユーザーが知る必要のない `schedule_trigger_setting_id` パラメータが REST API のレスポンスに含まれるパターンがあり、これが含まれていた場合は事前に削除するようにします。

```json
  "rule_value": {
      "time_zone": "Tokyo",
      "next_schedule": "2099-01-01 22:40:00 +0900",
      "schedule_trigger_setting_id": "901",
      "schedule": "2099-12-31 10:10:00\n2099-01-01 22:40:00"
  },
```