### PR TITLE
「RDS(Aurora): 過去のDBクラスタースナップショットをまとめて削除」アクションに対応した

### DIFF
--- a/examples/resources/cloudautomator_job/action/bulk_delete_rds_cluster_snapshots/main.tf
+++ b/examples/resources/cloudautomator_job/action/bulk_delete_rds_cluster_snapshots/main.tf
@@ -1,0 +1,32 @@
+# ----------------------------------------------------------
+# - アクション
+#   - RDS(Aurora): 過去のDBクラスタースナップショットをまとめて削除
+# - アクションの設定
+#   - 特定のタグが付いたDBクラスタースナップショットを除外するかどうか
+#     - 除外する
+#   - 除外するDBクラスタースナップショットの特定に利用するタグのキー
+#     - env
+#   - 除外するDBクラスタースナップショットの特定に利用するタグの値
+#     - production
+#   - 削除するDBクラスタースナップショットの指定方法
+#     - 日数で指定する
+#   - 削除するDBクラスタースナップショットを日数で指定する場合の日数
+#     - 365
+# ----------------------------------------------------------
+
+resource "cloudautomator_job" "example-bulk-delete-rds-cluster-snapshots-job" {
+  name            = "example-bulk-delete-rds-cluster-snapshots-job"
+  group_id        = 10
+  aws_account_ids = [20]
+
+  rule_type = "immediate_execution"
+
+  action_type = "bulk_delete_rds_cluster_snapshots"
+  bulk_delete_rds_cluster_snapshots_action_value {
+    exclude_by_tag_bulk_delete_rds_cluster_snapshots       = true
+    exclude_by_tag_key_bulk_delete_rds_cluster_snapshots   = "env"
+    exclude_by_tag_value_bulk_delete_rds_cluster_snapshots = "production"
+    specify_base_date                                      = "before_days"
+    before_days                                            = 365
+  }
+}

--- a/internal/provider/data_source_job.go
+++ b/internal/provider/data_source_job.go
@@ -96,6 +96,15 @@ func dataSourceJob() *schema.Resource {
 					Schema: aws.AuthorizeSecurityGroupIngressyActionValueFields(),
 				},
 			},
+			"bulk_delete_rds_cluster_snapshots_action_value": {
+				Description: "\"RDS(Aurora): Delete old DB cluster snapshots\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: aws.BulkDeleteRdsClusterSnapshotsActionValueFields(),
+				},
+			},
 			"bulk_stop_instances_action_value": {
 				Description: "\"EC2: Stop ALL instances\" action value",
 				Type:        schema.TypeList,

--- a/internal/provider/data_source_job_workflow_test.go
+++ b/internal/provider/data_source_job_workflow_test.go
@@ -43,10 +43,7 @@ resource "cloudautomator_job" "first_job" {
 
   for_workflow = true
 
-  action_type = "delay"
-  delay_action_value {
-	delay_minutes = 1
-  }
+  action_type = "no_action"
 }
 
 resource "cloudautomator_job" "following_job" {

--- a/internal/provider/resource_job.go
+++ b/internal/provider/resource_job.go
@@ -118,6 +118,15 @@ func resourceJob() *schema.Resource {
 					Schema: aws.AuthorizeSecurityGroupIngressyActionValueFields(),
 				},
 			},
+			"bulk_delete_rds_cluster_snapshots_action_value": {
+				Description: "\"RDS(Aurora): Delete old DB cluster snapshots\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: aws.BulkDeleteRdsClusterSnapshotsActionValueFields(),
+				},
+			},
 			"bulk_stop_instances_action_value": {
 				Description: "\"EC2: Stop ALL instances\" action value",
 				Type:        schema.TypeList,

--- a/internal/provider/resource_job.go
+++ b/internal/provider/resource_job.go
@@ -757,10 +757,11 @@ func resourceJobRead(ctx context.Context, d *schema.ResourceData, m interface{})
 	}
 
 	d.Set("action_type", job.ActionType)
-	actionValueBlockName := fmt.Sprintf("%s_action_value", job.ActionType)
-	if err := d.Set(actionValueBlockName, []interface{}{job.ActionValue}); err != nil {
-		diags = append(diags, diag.FromErr(err)...)
-		return diags
+	if job.ActionType != "no_action" {
+		actionValueBlockName := fmt.Sprintf("%s_action_value", job.ActionType)
+		if err := d.Set(actionValueBlockName, []interface{}{job.ActionValue}); err != nil {
+			return append(diags, diag.FromErr(err)...)
+		}
 	}
 
 	d.Set("allow_runtime_action_values", job.AllowRuntimeActionValues)

--- a/internal/provider/resource_job_test.go
+++ b/internal/provider/resource_job_test.go
@@ -338,6 +338,44 @@ func TestAccCloudAutomatorJob_AuthorizeSecurityGroupIngressAction(t *testing.T) 
 	})
 }
 
+func TestAccCloudAutomatorJob_BulkDeleteRdsClusterSnapshotsAction(t *testing.T) {
+	resourceName := "cloudautomator_job.test"
+	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
+	postProcessId := acctest.TestPostProcessId()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckCloudAutomatorJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudAutomatorJobConfigBulkDeleteRdsClusterSnapshotsAction(jobName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudAutomatorJobExists(testAccProviders["cloudautomator"], resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", jobName),
+					resource.TestCheckResourceAttr(
+						resourceName, "action_type", "bulk_delete_rds_cluster_snapshots"),
+					resource.TestCheckResourceAttr(
+						resourceName, "bulk_delete_rds_cluster_snapshots_action_value.0.exclude_by_tag_bulk_delete_rds_cluster_snapshots", "true"),
+					resource.TestCheckResourceAttr(
+						resourceName, "bulk_delete_rds_cluster_snapshots_action_value.0.exclude_by_tag_key_bulk_delete_rds_cluster_snapshots", "env"),
+					resource.TestCheckResourceAttr(
+						resourceName, "bulk_delete_rds_cluster_snapshots_action_value.0.exclude_by_tag_value_bulk_delete_rds_cluster_snapshots", "production"),
+					resource.TestCheckResourceAttr(
+						resourceName, "bulk_delete_rds_cluster_snapshots_action_value.0.specify_base_date", "before_days"),
+					resource.TestCheckResourceAttr(
+						resourceName, "bulk_delete_rds_cluster_snapshots_action_value.0.before_days", "365"),
+					resource.TestCheckResourceAttr(
+						resourceName, "completed_post_process_id.0", postProcessId),
+					resource.TestCheckResourceAttr(
+						resourceName, "failed_post_process_id.0", postProcessId),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudAutomatorJob_BulkStopInstancesAction(t *testing.T) {
 	resourceName := "cloudautomator_job.test"
 	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
@@ -2680,6 +2718,29 @@ resource "cloudautomator_job" "test" {
 		to_port = "80"
 		cidr_ip = "172.31.0.0/16"
 	}
+	completed_post_process_id = [%s]
+	failed_post_process_id = [%s]
+}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}
+
+func testAccCheckCloudAutomatorJobConfigBulkDeleteRdsClusterSnapshotsAction(rName string) string {
+	return fmt.Sprintf(`
+resource "cloudautomator_job" "test" {
+	name = "%s"
+	group_id = "%s"
+	aws_account_ids = [%s]
+
+	rule_type = "webhook"
+
+	action_type = "bulk_delete_rds_cluster_snapshots"
+	bulk_delete_rds_cluster_snapshots_action_value {
+		exclude_by_tag_bulk_delete_rds_cluster_snapshots = true
+		exclude_by_tag_key_bulk_delete_rds_cluster_snapshots = "env"
+		exclude_by_tag_value_bulk_delete_rds_cluster_snapshots = "production"
+		specify_base_date = "before_days"
+		before_days = 365
+	}
+
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]
 }`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())

--- a/internal/provider/resource_job_workflow_test.go
+++ b/internal/provider/resource_job_workflow_test.go
@@ -99,10 +99,7 @@ resource "cloudautomator_job" "first_job" {
 
   for_workflow = true
 
-  action_type = "delay"
-  delay_action_value {
-	delay_minutes = 1
-  }
+  action_type = "no_action"
 }
 
 resource "cloudautomator_job" "following_job" {

--- a/internal/schemes/job/aws/rds.go
+++ b/internal/schemes/job/aws/rds.go
@@ -4,6 +4,41 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+func BulkDeleteRdsClusterSnapshotsActionValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"exclude_by_tag_bulk_delete_rds_cluster_snapshots": {
+			Description: "Specifies whether to exclude DB cluster snapshots with certain tags from deletion",
+			Type:        schema.TypeBool,
+			Required:    true,
+		},
+		"exclude_by_tag_key_bulk_delete_rds_cluster_snapshots": {
+			Description: "The tag key used to identify DB cluster snapshots to exclude from deletion",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"exclude_by_tag_value_bulk_delete_rds_cluster_snapshots": {
+			Description: "The tag value used to identify DB cluster snapshots to exclude from deletion",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"specify_base_date": {
+			Description: "Specifies the method for determining which DB cluster snapshots to delete",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"before_days": {
+			Description: "The number of days used to identify DB cluster snapshots to be deleted",
+			Type:        schema.TypeInt,
+			Optional:    true,
+		},
+		"before_date": {
+			Description: "The date used to identify DB cluster snapshots for deletion",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+	}
+}
+
 func ChangeRdsInstanceClassActionValueFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"region": {


### PR DESCRIPTION
「RDS(Aurora): 過去のDBクラスタースナップショットをまとめて削除」アクションに対応しました。

```tf
# ----------------------------------------------------------
# - アクション
#   - RDS(Aurora): 過去のDBクラスタースナップショットをまとめて削除
# - アクションの設定
#   - 特定のタグが付いたDBクラスタースナップショットを除外するかどうか
#     - 除外する
#   - 除外するDBクラスタースナップショットの特定に利用するタグのキー
#     - env
#   - 除外するDBクラスタースナップショットの特定に利用するタグの値
#     - production
#   - 削除するDBクラスタースナップショットの指定方法
#     - 日数で指定する
#   - 削除するDBクラスタースナップショットを日数で指定する場合の日数
#     - 365
# ----------------------------------------------------------

resource "cloudautomator_job" "example-bulk-delete-rds-cluster-snapshots-job" {
  name            = "example-bulk-delete-rds-cluster-snapshots-job"
  group_id        = 10
  aws_account_ids = [20]

  rule_type = "immediate_execution"

  action_type = "bulk_delete_rds_cluster_snapshots"
  bulk_delete_rds_cluster_snapshots_action_value {
    exclude_by_tag_bulk_delete_rds_cluster_snapshots       = true
    exclude_by_tag_key_bulk_delete_rds_cluster_snapshots   = "env"
    exclude_by_tag_value_bulk_delete_rds_cluster_snapshots = "production"
    specify_base_date                                      = "before_days"
    before_days                                            = 365
  }
}
```