### PR TITLE
「EC2: 過去のAMIとスナップショットをまとめて削除」アクションに対応した

### DIFF
--- a/examples/resources/cloudautomator_job/action/bulk_delete_images/main.tf
+++ b/examples/resources/cloudautomator_job/action/bulk_delete_images/main.tf
@@ -1,0 +1,32 @@
+# ----------------------------------------------------------
+# - アクション
+#   - EC2: 過去のAMIとスナップショットをまとめて削除
+# - アクションの設定
+#   - 特定のタグが付いたAMIを除外するかどうか
+#     - 除外する
+#   - 除外するAMIの特定に利用するタグのキー
+#     - env
+#   - 除外するAMIの特定に利用するタグの値
+#     - production
+#   - 削除するAMIの指定方法
+#     - 日数で指定する
+#   - 削除するAMIを日数で指定する場合の日数
+#     - 365
+# ----------------------------------------------------------
+
+resource "cloudautomator_job" "example-bulk-delete-images-job" {
+  name            = "example-bulk-delete-images-job"
+  group_id        = 10
+  aws_account_ids = [20]
+
+  rule_type = "immediate_execution"
+
+  action_type = "bulk_delete_images"
+  bulk_delete_images_action_value {
+    exclude_by_tag_bulk_delete_images       = true
+    exclude_by_tag_key_bulk_delete_images   = "env"
+    exclude_by_tag_value_bulk_delete_images = "production"
+    specify_base_date                       = "before_days"
+    before_days                             = 365
+  }
+}

--- a/internal/provider/data_source_job.go
+++ b/internal/provider/data_source_job.go
@@ -96,6 +96,15 @@ func dataSourceJob() *schema.Resource {
 					Schema: aws.AuthorizeSecurityGroupIngressyActionValueFields(),
 				},
 			},
+			"bulk_delete_images_action_value": {
+				Description: "\"EC2: Delete old AMIs and Snapshots\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: aws.BulkDeleteImagesActionValueFields(),
+				},
+			},
 			"bulk_delete_rds_cluster_snapshots_action_value": {
 				Description: "\"RDS(Aurora): Delete old DB cluster snapshots\" action value",
 				Type:        schema.TypeList,

--- a/internal/provider/resource_job.go
+++ b/internal/provider/resource_job.go
@@ -118,6 +118,15 @@ func resourceJob() *schema.Resource {
 					Schema: aws.AuthorizeSecurityGroupIngressyActionValueFields(),
 				},
 			},
+			"bulk_delete_images_action_value": {
+				Description: "\"EC2: Delete old AMIs and Snapshots\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: aws.BulkDeleteImagesActionValueFields(),
+				},
+			},
 			"bulk_delete_rds_cluster_snapshots_action_value": {
 				Description: "\"RDS(Aurora): Delete old DB cluster snapshots\" action value",
 				Type:        schema.TypeList,

--- a/internal/provider/resource_job_test.go
+++ b/internal/provider/resource_job_test.go
@@ -338,6 +338,44 @@ func TestAccCloudAutomatorJob_AuthorizeSecurityGroupIngressAction(t *testing.T) 
 	})
 }
 
+func TestAccCloudAutomatorJob_BulkDeleteImagesAction(t *testing.T) {
+	resourceName := "cloudautomator_job.test"
+	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
+	postProcessId := acctest.TestPostProcessId()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckCloudAutomatorJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudAutomatorJobConfigBulkDeleteImagesAction(jobName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudAutomatorJobExists(testAccProviders["cloudautomator"], resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", jobName),
+					resource.TestCheckResourceAttr(
+						resourceName, "action_type", "bulk_delete_images"),
+					resource.TestCheckResourceAttr(
+						resourceName, "bulk_delete_images_action_value.0.exclude_by_tag_bulk_delete_images", "true"),
+					resource.TestCheckResourceAttr(
+						resourceName, "bulk_delete_images_action_value.0.exclude_by_tag_key_bulk_delete_images", "env"),
+					resource.TestCheckResourceAttr(
+						resourceName, "bulk_delete_images_action_value.0.exclude_by_tag_value_bulk_delete_images", "production"),
+					resource.TestCheckResourceAttr(
+						resourceName, "bulk_delete_images_action_value.0.specify_base_date", "before_days"),
+					resource.TestCheckResourceAttr(
+						resourceName, "bulk_delete_images_action_value.0.before_days", "365"),
+					resource.TestCheckResourceAttr(
+						resourceName, "completed_post_process_id.0", postProcessId),
+					resource.TestCheckResourceAttr(
+						resourceName, "failed_post_process_id.0", postProcessId),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudAutomatorJob_BulkDeleteRdsClusterSnapshotsAction(t *testing.T) {
 	resourceName := "cloudautomator_job.test"
 	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
@@ -2718,6 +2756,29 @@ resource "cloudautomator_job" "test" {
 		to_port = "80"
 		cidr_ip = "172.31.0.0/16"
 	}
+	completed_post_process_id = [%s]
+	failed_post_process_id = [%s]
+}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}
+
+func testAccCheckCloudAutomatorJobConfigBulkDeleteImagesAction(rName string) string {
+	return fmt.Sprintf(`
+resource "cloudautomator_job" "test" {
+	name = "%s"
+	group_id = "%s"
+	aws_account_ids = [%s]
+
+	rule_type = "webhook"
+
+	action_type = "bulk_delete_images"
+	bulk_delete_images_action_value {
+		exclude_by_tag_bulk_delete_images = true
+		exclude_by_tag_key_bulk_delete_images = "env"
+		exclude_by_tag_value_bulk_delete_images = "production"
+		specify_base_date = "before_days"
+		before_days = 365
+	}
+
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]
 }`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())

--- a/internal/schemes/job/aws/ec2.go
+++ b/internal/schemes/job/aws/ec2.go
@@ -49,6 +49,41 @@ func AuthorizeSecurityGroupIngressyActionValueFields() map[string]*schema.Schema
 	}
 }
 
+func BulkDeleteImagesActionValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"exclude_by_tag_bulk_delete_images": {
+			Description: "Specifies whether to exclude AMIs with certain tags from deletion",
+			Type:        schema.TypeBool,
+			Required:    true,
+		},
+		"exclude_by_tag_key_bulk_delete_images": {
+			Description: "The tag key used to identify AMIs to exclude from deletion",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"exclude_by_tag_value_bulk_delete_images": {
+			Description: "The tag value used to identify AMIs to exclude from deletion",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"specify_base_date": {
+			Description: "Specifies the method for determining which AMIs to delete",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"before_days": {
+			Description: "The number of days used to identify AMIs to be deleted",
+			Type:        schema.TypeInt,
+			Optional:    true,
+		},
+		"before_date": {
+			Description: "The date used to identify AMIs for deletion",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+	}
+}
+
 func BulkStopInstancesActionValueFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"exclude_by_tag": {


### PR DESCRIPTION
「EC2: 過去のAMIとスナップショットをまとめて削除」アクションに対応しました。

```tf
# ----------------------------------------------------------
# - アクション
#   - EC2: 過去のAMIとスナップショットをまとめて削除
# - アクションの設定
#   - 特定のタグが付いたAMIを除外するかどうか
#     - 除外する
#   - 除外するAMIの特定に利用するタグのキー
#     - env
#   - 除外するAMIの特定に利用するタグの値
#     - production
#   - 削除するAMIの指定方法
#     - 日数で指定する
#   - 削除するAMIを日数で指定する場合の日数
#     - 365
# ----------------------------------------------------------

resource "cloudautomator_job" "example-bulk-delete-images-job" {
  name            = "example-bulk-delete-images-job"
  group_id        = 10
  aws_account_ids = [20]

  rule_type = "immediate_execution"

  action_type = "bulk_delete_images"
  bulk_delete_images_action_value {
    exclude_by_tag_bulk_delete_images       = true
    exclude_by_tag_key_bulk_delete_images   = "env"
    exclude_by_tag_value_bulk_delete_images = "production"
    specify_base_date                       = "before_days"
    before_days                             = 365
  }
}
```