### PR TITLE
「EC2: インスタンスをバックアップ」アクションに対応した

### DIFF
--- a/docs/data-sources/job.md
+++ b/docs/data-sources/job.md
@@ -56,6 +56,7 @@ data "cloudautomator_job" "example-job" {
 - `detach_user_policy_action_value` (Block List, Max: 1) "IAM: Detach Policy to IAM User" action value (see [below for nested schema](#nestedblock--detach_user_policy_action_value))
 - `disaster_recovery_action_value` (Block List, Max: 1) "DR: Launch EC2 instance" action value (see [below for nested schema](#nestedblock--disaster_recovery_action_value))
 - `dynamodb_start_backup_job_action_value` (Block List, Max: 1) "DynamoDB: Backup table" action value (see [below for nested schema](#nestedblock--dynamodb_start_backup_job_action_value))
+- `ec2_start_backup_job_action_value` (Block List, Max: 1) "EC2: Backup instance" action value (see [below for nested schema](#nestedblock--ec2_start_backup_job_action_value))
 - `google_compute_insert_machine_image_action_value` (Block List, Max: 1) "Compute Engine: create machine image" action value (see [below for nested schema](#nestedblock--google_compute_insert_machine_image_action_value))
 - `reboot_rds_instances_action_value` (Block List, Max: 1) "RDS: Reboot DB instance" action value (see [below for nested schema](#nestedblock--reboot_rds_instances_action_value))
 - `reboot_workspaces_action_value` (Block List, Max: 1) "WorkSpaces: Reboot WorkSpace" action value (see [below for nested schema](#nestedblock--reboot_workspaces_action_value))
@@ -566,6 +567,34 @@ Optional:
 
 <a id="nestedblock--dynamodb_start_backup_job_action_value--additional_tags"></a>
 ### Nested Schema for `dynamodb_start_backup_job_action_value.additional_tags`
+
+Required:
+
+- `key` (String)
+- `value` (String)
+
+
+
+<a id="nestedblock--ec2_start_backup_job_action_value"></a>
+### Nested Schema for `ec2_start_backup_job_action_value`
+
+Required:
+
+- `backup_vault_name` (String) Backup Vault Name
+- `iam_role_arn` (String) IAM Role ARN
+- `region` (String) AWS Region
+- `specify_instance` (String) How to identify target resources
+
+Optional:
+
+- `additional_tags` (Block Set) Array of tags to be added to the recovery point (see [below for nested schema](#nestedblock--ec2_start_backup_job_action_value--additional_tags))
+- `instance_id` (String) Target EC2 instance ID
+- `lifecycle_delete_after_days` (Number) Number of days to hold recovery point
+- `tag_key` (String) Tag key used to identify the target resource
+- `tag_value` (String) Tag value used to identify the target resource
+
+<a id="nestedblock--ec2_start_backup_job_action_value--additional_tags"></a>
+### Nested Schema for `ec2_start_backup_job_action_value.additional_tags`
 
 Required:
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -113,6 +113,7 @@ resource "cloudautomator_job" "example-create-image-job" {
 - `detach_user_policy_action_value` (Block List, Max: 1) "IAM: Detach Policy to IAM User" action value (see [below for nested schema](#nestedblock--detach_user_policy_action_value))
 - `disaster_recovery_action_value` (Block List, Max: 1) "DR: Launch EC2 instance" action value (see [below for nested schema](#nestedblock--disaster_recovery_action_value))
 - `dynamodb_start_backup_job_action_value` (Block List, Max: 1) "DynamoDB: Backup table" action value (see [below for nested schema](#nestedblock--dynamodb_start_backup_job_action_value))
+- `ec2_start_backup_job_action_value` (Block List, Max: 1) "EC2: Backup instance" action value (see [below for nested schema](#nestedblock--ec2_start_backup_job_action_value))
 - `effective_date` (String) Effective date
 - `expiration_date` (String) Expiration date
 - `failed_post_process_id` (List of Number) Array containing post-process IDs to be executed if the job fails
@@ -654,6 +655,34 @@ Optional:
 
 <a id="nestedblock--dynamodb_start_backup_job_action_value--additional_tags"></a>
 ### Nested Schema for `dynamodb_start_backup_job_action_value.additional_tags`
+
+Required:
+
+- `key` (String)
+- `value` (String)
+
+
+
+<a id="nestedblock--ec2_start_backup_job_action_value"></a>
+### Nested Schema for `ec2_start_backup_job_action_value`
+
+Required:
+
+- `backup_vault_name` (String) Backup Vault Name
+- `iam_role_arn` (String) IAM Role ARN
+- `region` (String) AWS Region
+- `specify_instance` (String) How to identify target resources
+
+Optional:
+
+- `additional_tags` (Block Set) Array of tags to be added to the recovery point (see [below for nested schema](#nestedblock--ec2_start_backup_job_action_value--additional_tags))
+- `instance_id` (String) Target EC2 instance ID
+- `lifecycle_delete_after_days` (Number) Number of days to hold recovery point
+- `tag_key` (String) Tag key used to identify the target resource
+- `tag_value` (String) Tag value used to identify the target resource
+
+<a id="nestedblock--ec2_start_backup_job_action_value--additional_tags"></a>
+### Nested Schema for `ec2_start_backup_job_action_value.additional_tags`
 
 Required:
 

--- a/examples/resources/cloudautomator_job/action/ec2_start_backup_job/main.tf
+++ b/examples/resources/cloudautomator_job/action/ec2_start_backup_job/main.tf
@@ -1,0 +1,90 @@
+# ----------------------------------------------------------
+# - アクション
+#   - EC2: インスタンスをバックアップ
+# - アクションの設定
+#   - 対象のインスタンスとバックアップボールトが存在するAWSリージョン
+#     - ap-northeast-1
+#   - 対象のインスタンスのID
+#     - i-00000001
+#   - 対象のバックアップボールトの名前
+#     - example-backup
+#   - バックアップの保持期間(日数)
+#     - 無期限
+#   - バックアップ取得時に使うIAMロールのARN
+#     - arn:aws:iam::123456789012:role/RoleForBackup
+# ----------------------------------------------------------
+
+resource "cloudautomator_job" "example-ec2-start-backup-job" {
+  name           = "example-ec2-start-backup-job"
+  group_id       = 10
+  aws_account_id = 20
+
+  rule_type = "immediate_execution"
+
+  action_type = "ec2_start_backup_job"
+  ec2_start_backup_job_action_value {
+    region                      = "ap-northeast-1"
+    specify_instance            = "identifier"
+    instance_id                 = "i-00000001"
+    backup_vault_name           = "example-backup"
+    lifecycle_delete_after_days = null
+    iam_role_arn                = "arn:aws:iam::123456789012:role/RoleForBackup"
+  }
+}
+
+# ----------------------------------------------------------
+# - アクション
+#   - EC2: インスタンスをバックアップ
+# - アクションの設定
+#   - 対象のインスタンスとバックアップボールトが存在するAWSリージョン
+#     - ap-northeast-1
+#   - タグで対象のインスタンスを指定
+#     - タグのキー
+#       - env
+#     - タグの値
+#       - production
+#   - 対象のバックアップボールトの名前
+#     - example-backup
+#   - バックアップの保持期間(日数)
+#     - 7
+#   - バックアップ取得時に使うIAMロールのARN
+#     - arn:aws:iam::123456789012:role/RoleForBackup
+#   - 作成した復旧ポイントに割り当てるタグの配列
+#     - key1: value1
+#     - key2: value2
+#     - key3: value3
+# ----------------------------------------------------------
+
+resource "cloudautomator_job" "example-ec2-start-backup-job" {
+  name           = "example-ec2-start-backup-job"
+  group_id       = 10
+  aws_account_id = 20
+
+  rule_type = "immediate_execution"
+
+  action_type = "ec2_start_backup_job"
+  ec2_start_backup_job_action_value {
+    region                      = "ap-northeast-1"
+    specify_instance            = "tag"
+    tag_key                     = "env"
+    tag_value                   = "production"
+    backup_vault_name           = "example-backup"
+    lifecycle_delete_after_days = 7
+    iam_role_arn                = "arn:aws:iam::123456789012:role/RoleForBackup"
+
+    additional_tags {
+      key   = "key1"
+      value = "value1"
+    }
+
+    additional_tags {
+      key   = "key2"
+      value = "value2"
+    }
+
+    additional_tags {
+      key   = "key3"
+      value = "value3"
+    }
+  }
+}

--- a/internal/provider/data_source_job.go
+++ b/internal/provider/data_source_job.go
@@ -339,6 +339,15 @@ func dataSourceJob() *schema.Resource {
 					Schema: aws.DynamodbStartBackupJobActionValueFields(),
 				},
 			},
+			"ec2_start_backup_job_action_value": {
+				Description: "\"EC2: Backup instance\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: aws.Ec2StartBackupJobActionValueFields(),
+				},
+			},
 			"google_compute_insert_machine_image_action_value": {
 				Description: "\"Compute Engine: create machine image\" action value",
 				Type:        schema.TypeList,

--- a/internal/provider/resource_job.go
+++ b/internal/provider/resource_job.go
@@ -361,6 +361,15 @@ func resourceJob() *schema.Resource {
 					Schema: aws.DynamodbStartBackupJobActionValueFields(),
 				},
 			},
+			"ec2_start_backup_job_action_value": {
+				Description: "\"EC2: Backup instance\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: aws.Ec2StartBackupJobActionValueFields(),
+				},
+			},
 			"google_compute_insert_machine_image_action_value": {
 				Description: "\"Compute Engine: create machine image\" action value",
 				Type:        schema.TypeList,
@@ -933,7 +942,7 @@ func buildActionValue(d *schema.ResourceData, job *client.Job) map[string]interf
 	}
 
 	switch job.ActionType {
-	case "dynamodb_start_backup_job":
+	case "dynamodb_start_backup_job", "ec2_start_backup_job":
 		if actionValue["lifecycle_delete_after_days"] == 0 {
 			actionValue["lifecycle_delete_after_days"] = nil
 		}

--- a/internal/provider/resource_job_test.go
+++ b/internal/provider/resource_job_test.go
@@ -1226,6 +1226,64 @@ func TestAccCloudAutomatorJob(t *testing.T) {
 			},
 		},
 		{
+			name:    "Ec2StartBackupJobAction",
+			jobName: fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12)),
+			configFunc: func(resourceName string) string {
+				return fmt.Sprintf(`
+			resource "cloudautomator_job" "test" {
+				name = "%s"
+				group_id = "%s"
+				aws_account_id = "%s"
+
+				rule_type = "webhook"
+
+				action_type = "ec2_start_backup_job"
+				ec2_start_backup_job_action_value {
+				  region                      = "ap-northeast-1"
+				  specify_instance            = "tag"
+          tag_key                     = "env"
+          tag_value                   = "production"
+				  lifecycle_delete_after_days = 7
+				  backup_vault_name           = "example-vault"
+				  iam_role_arn                = "arn:aws:iam::123456789012:role/example-role"
+
+				  additional_tags {
+					key   = "key1"
+					value = "value1"
+				  }
+
+				  additional_tags {
+					key   = "key2"
+					value = "value2"
+				  }
+
+				  additional_tags {
+					key   = "key3"
+					value = "value3"
+				  }
+				}
+				completed_post_process_id = [%s]
+				failed_post_process_id = [%s]
+			}`, resourceName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+			},
+			checks: []resource.TestCheckFunc{
+				resource.TestCheckResourceAttr("cloudautomator_job.test", "action_type", "ec2_start_backup_job"),
+				resource.TestCheckResourceAttr("cloudautomator_job.test", "ec2_start_backup_job_action_value.0.region", "ap-northeast-1"),
+				resource.TestCheckResourceAttr("cloudautomator_job.test", "ec2_start_backup_job_action_value.0.specify_instance", "tag"),
+				resource.TestCheckResourceAttr("cloudautomator_job.test", "ec2_start_backup_job_action_value.0.tag_key", "env"),
+				resource.TestCheckResourceAttr("cloudautomator_job.test", "ec2_start_backup_job_action_value.0.tag_value", "production"),
+				resource.TestCheckResourceAttr("cloudautomator_job.test", "ec2_start_backup_job_action_value.0.lifecycle_delete_after_days", "7"),
+				resource.TestCheckResourceAttr("cloudautomator_job.test", "ec2_start_backup_job_action_value.0.backup_vault_name", "example-vault"),
+				resource.TestCheckResourceAttr("cloudautomator_job.test", "ec2_start_backup_job_action_value.0.iam_role_arn", "arn:aws:iam::123456789012:role/example-role"),
+				resource.TestCheckResourceAttr("cloudautomator_job.test", "ec2_start_backup_job_action_value.0.additional_tags.0.key", "key1"),
+				resource.TestCheckResourceAttr("cloudautomator_job.test", "ec2_start_backup_job_action_value.0.additional_tags.0.value", "value1"),
+				resource.TestCheckResourceAttr("cloudautomator_job.test", "ec2_start_backup_job_action_value.0.additional_tags.1.key", "key2"),
+				resource.TestCheckResourceAttr("cloudautomator_job.test", "ec2_start_backup_job_action_value.0.additional_tags.1.value", "value2"),
+				resource.TestCheckResourceAttr("cloudautomator_job.test", "ec2_start_backup_job_action_value.0.additional_tags.2.key", "key3"),
+				resource.TestCheckResourceAttr("cloudautomator_job.test", "ec2_start_backup_job_action_value.0.additional_tags.2.value", "value3"),
+			},
+		},
+		{
 			name:    "GoogleComputeInsertMachineImageAction",
 			jobName: fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12)),
 			configFunc: func(resourceName string) string {

--- a/internal/schemes/job/aws/ec2.go
+++ b/internal/schemes/job/aws/ec2.go
@@ -418,6 +418,68 @@ func CreateImageActionValueFields() map[string]*schema.Schema {
 	}
 }
 
+func Ec2StartBackupJobActionValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"region": {
+			Description: "AWS Region",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"specify_instance": {
+			Description: "How to identify target resources",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"instance_id": {
+			Description: "Target EC2 instance ID",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"tag_key": {
+			Description: "Tag key used to identify the target resource",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"tag_value": {
+			Description: "Tag value used to identify the target resource",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"backup_vault_name": {
+			Description: "Backup Vault Name",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"lifecycle_delete_after_days": {
+			Description: "Number of days to hold recovery point",
+			Type:        schema.TypeInt,
+			Optional:    true,
+		},
+		"iam_role_arn": {
+			Description: "IAM Role ARN",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"additional_tags": {
+			Description: "Array of tags to be added to the recovery point",
+			Type:        schema.TypeSet,
+			Optional:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"key": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"value": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+	}
+}
+
 func RevokeSecurityGroupIngressActionValueFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"region": {


### PR DESCRIPTION
「EC2: インスタンスをバックアップ」アクションに対応しました。

## resource example

```hcl
# ----------------------------------------------------------
# - アクション
#   - EC2: インスタンスをバックアップ
# - アクションの設定
#   - 対象のインスタンスとバックアップボールトが存在するAWSリージョン
#     - ap-northeast-1
#   - 対象のインスタンスのID
#     - i-00000001
#   - 対象のバックアップボールトの名前
#     - example-backup
#   - バックアップの保持期間(日数)
#     - 無期限
#   - バックアップ取得時に使うIAMロールのARN
#     - arn:aws:iam::123456789012:role/RoleForBackup
# ----------------------------------------------------------

resource "cloudautomator_job" "example-ec2-start-backup-job" {
  name           = "example-ec2-start-backup-job"
  group_id       = 10
  aws_account_id = 20

  rule_type = "immediate_execution"

  action_type = "ec2_start_backup_job"
  ec2_start_backup_job_action_value {
    region                      = "ap-northeast-1"
    specify_instance            = "identifier"
    instance_id                 = "i-00000001"
    backup_vault_name           = "example-backup"
    lifecycle_delete_after_days = null
    iam_role_arn                = "arn:aws:iam::123456789012:role/RoleForBackup"
  }
}

# ----------------------------------------------------------
# - アクション
#   - EC2: インスタンスをバックアップ
# - アクションの設定
#   - 対象のインスタンスとバックアップボールトが存在するAWSリージョン
#     - ap-northeast-1
#   - タグで対象のインスタンスを指定
#     - タグのキー
#       - env
#     - タグの値
#       - production
#   - 対象のバックアップボールトの名前
#     - example-backup
#   - バックアップの保持期間(日数)
#     - 7
#   - バックアップ取得時に使うIAMロールのARN
#     - arn:aws:iam::123456789012:role/RoleForBackup
#   - 作成した復旧ポイントに割り当てるタグの配列
#     - key1: value1
#     - key2: value2
#     - key3: value3
# ----------------------------------------------------------

resource "cloudautomator_job" "example-ec2-start-backup-job" {
  name           = "example-ec2-start-backup-job"
  group_id       = 10
  aws_account_id = 20

  rule_type = "immediate_execution"

  action_type = "ec2_start_backup_job"
  ec2_start_backup_job_action_value {
    region                      = "ap-northeast-1"
    specify_instance            = "tag"
    tag_key                     = "env"
    tag_value                   = "production"
    backup_vault_name           = "example-backup"
    lifecycle_delete_after_days = 7
    iam_role_arn                = "arn:aws:iam::123456789012:role/RoleForBackup"

    additional_tags {
      key   = "key1"
      value = "value1"
    }

    additional_tags {
      key   = "key2"
      value = "value2"
    }

    additional_tags {
      key   = "key3"
      value = "value3"
    }
  }
}
```

## References

- [REST API documentation](https://api.cloudautomator.com/#header--34)
