### PR TITLE
copy_image アクションに不足していた generation フィールドを追加した

### DIFF
--- a/docs/data-sources/job.md
+++ b/docs/data-sources/job.md
@@ -262,13 +262,14 @@ Required:
 - `destination_region` (String) AWS Region to copy to
 - `source_region` (String) AWS Region from which the copy was made
 - `specify_image` (String) How to identify target resources
-- `trace_status` (String) Whether to Verify completion status of the resource
 
 Optional:
 
+- `generation` (Number) Number of AMI generations to be managed (0-10). Required when specify_image is 'tag'
 - `source_image_id` (String) 対象のAMIのID
 - `tag_key` (String) Tag key used to identify the target resource
 - `tag_value` (String) Tag value used to identify the target resource
+- `trace_status` (String) Whether to Verify completion status of the resource
 
 
 <a id="nestedblock--copy_rds_cluster_snapshot_action_value"></a>

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -318,13 +318,14 @@ Required:
 - `destination_region` (String) AWS Region to copy to
 - `source_region` (String) AWS Region from which the copy was made
 - `specify_image` (String) How to identify target resources
-- `trace_status` (String) Whether to Verify completion status of the resource
 
 Optional:
 
+- `generation` (Number) Number of AMI generations to be managed (0-10). Required when specify_image is 'tag'
 - `source_image_id` (String) 対象のAMIのID
 - `tag_key` (String) Tag key used to identify the target resource
 - `tag_value` (String) Tag value used to identify the target resource
+- `trace_status` (String) Whether to Verify completion status of the resource
 
 
 <a id="nestedblock--copy_rds_cluster_snapshot_action_value"></a>

--- a/internal/provider/resource_job_test.go
+++ b/internal/provider/resource_job_test.go
@@ -620,6 +620,7 @@ func TestAccCloudAutomatorJob(t *testing.T) {
 					specify_image = "tag"
 					tag_key = "env"
 					tag_value = "develop"
+					generation = 10
 					trace_status = "true"
 				}
 				completed_post_process_id = [%s]
@@ -633,6 +634,7 @@ func TestAccCloudAutomatorJob(t *testing.T) {
 				resource.TestCheckResourceAttr("cloudautomator_job.test", "copy_image_action_value.0.specify_image", "tag"),
 				resource.TestCheckResourceAttr("cloudautomator_job.test", "copy_image_action_value.0.tag_key", "env"),
 				resource.TestCheckResourceAttr("cloudautomator_job.test", "copy_image_action_value.0.tag_value", "develop"),
+				resource.TestCheckResourceAttr("cloudautomator_job.test", "copy_image_action_value.0.generation", "10"),
 				resource.TestCheckResourceAttr("cloudautomator_job.test", "copy_image_action_value.0.trace_status", "true"),
 			},
 		},

--- a/internal/schemes/job/aws/ec2.go
+++ b/internal/schemes/job/aws/ec2.go
@@ -246,10 +246,15 @@ func CopyImageActionValueFields() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 		},
+		"generation": {
+			Description: "Number of AMI generations to be managed (0-10). Required when specify_image is 'tag'",
+			Type:        schema.TypeInt,
+			Optional:    true,
+		},
 		"trace_status": {
 			Description: "Whether to Verify completion status of the resource",
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 		},
 	}
 }


### PR DESCRIPTION
## 概要
copy_image アクションに不足していた generation フィールドを追加しました。

```
Error: request failed. StatusCode=400 Reason={"errors":[{"source":{"pointer":"/data/attributes/generation"},"detail":"は数値で入力してください"}]}
```